### PR TITLE
Initialize project structure with stubs

### DIFF
--- a/examples/datasets/sample_note.txt
+++ b/examples/datasets/sample_note.txt
@@ -1,0 +1,3 @@
+Met with Divya to discuss AI orchestration.
+She suggested trying small Gemma models.
+Follow up: Build a demo repo next week.

--- a/examples/manual_plans/sample_plan.yaml
+++ b/examples/manual_plans/sample_plan.yaml
@@ -1,0 +1,9 @@
+version: "0.1"
+graph:
+  - id: extract
+    tool: "extractor_A.v1"
+    inputs:
+      text: "${context.text}"
+    out:
+      triples: "$.triples"
+      mentions: "$.mentions"

--- a/examples/run_hello.py
+++ b/examples/run_hello.py
@@ -1,0 +1,19 @@
+"""Hello world example for micrographonia.
+
+This script demonstrates the intended API and writes a placeholder JSON file.
+"""
+
+import json
+from pathlib import Path
+
+
+def main() -> None:  # pragma: no cover - stub
+    """Run the hello world example."""
+    data = {"triples": [["A", "rel", "B"], ["C", "rel", "D"]]}
+    out_path = Path(__file__).parent / "kg.json"
+    out_path.write_text(json.dumps(data, indent=2))
+    print(f"✅ Wrote {len(data['triples'])} triples to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/micrographonia/__init__.py
+++ b/micrographonia/__init__.py
@@ -1,0 +1,6 @@
+"""Top-level package for micrographonia.
+
+This package orchestrates tiny specialist models into structured reasoning pipelines.
+"""
+
+__all__ = ["runtime", "registry", "tools", "sdk"]

--- a/micrographonia/docs/README.md
+++ b/micrographonia/docs/README.md
@@ -1,0 +1,5 @@
+# Micrographonia Documentation
+
+This directory will contain background materials, plan IR specifications, and tutorials.
+
+More detailed documentation will be added as the project evolves.

--- a/micrographonia/registry/__init__.py
+++ b/micrographonia/registry/__init__.py
@@ -1,0 +1,17 @@
+"""Registry of tool manifests.
+
+This module will manage tool schemas and endpoints.
+"""
+
+class ToolRegistry:
+    """Stub registry for tool metadata."""
+
+    def register(self, name: str, manifest: dict) -> None:  # pragma: no cover - stub
+        """Register a tool manifest."""
+        # TODO: store manifest information
+        _ = (name, manifest)
+
+    def get(self, name: str) -> dict | None:  # pragma: no cover - stub
+        """Retrieve a manifest by name."""
+        # TODO: implement lookup
+        return None

--- a/micrographonia/runtime/__init__.py
+++ b/micrographonia/runtime/__init__.py
@@ -1,0 +1,20 @@
+"""Runtime package.
+
+Contains the plan execution engine that runs tool DAGs.
+Currently provides stub implementations.
+"""
+
+class PlanRuntime:
+    """Stub runtime that will execute plan graphs."""
+
+    def run(self, plan: dict) -> dict:  # pragma: no cover - stub
+        """Execute a plan and return its outputs.
+
+        Args:
+            plan: A dictionary representing the plan DAG.
+
+        Returns:
+            A dictionary of outputs.
+        """
+        # TODO: implement runtime logic
+        return {}

--- a/micrographonia/sdk/__init__.py
+++ b/micrographonia/sdk/__init__.py
@@ -1,0 +1,9 @@
+"""SDK and CLI interfaces for micrographonia.
+
+Provides user-facing utilities to run plans and interact with the system.
+"""
+
+def run_plan(plan_path: str) -> None:  # pragma: no cover - stub
+    """Load and run a plan from disk."""
+    # TODO: parse YAML plan and invoke runtime
+    _ = plan_path

--- a/micrographonia/tools/__init__.py
+++ b/micrographonia/tools/__init__.py
@@ -1,0 +1,14 @@
+"""Collection of stub tool services.
+
+Each tool is intended to be replaced by a small specialized model.
+"""
+
+class BaseTool:
+    """Base class for tool stubs."""
+
+    name: str = "base_tool"
+
+    def run(self, *args, **kwargs):  # pragma: no cover - stub
+        """Execute the tool with given arguments."""
+        # TODO: implement tool behavior
+        return {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "micrographonia"
+version = "0.1.0"
+description = "Composable small models for structured reasoning."
+authors = [
+  { name = "Micrographonia Team" }
+]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []


### PR DESCRIPTION
## Summary
- bootstrap package layout for runtime, registry, tools, SDK and docs
- add example plan, dataset and hello world script
- introduce pyproject.toml for packaging

## Testing
- `python -m pytest`
- `python examples/run_hello.py`


------
https://chatgpt.com/codex/tasks/task_e_68a23b7a9a2083269ee97e9a64fc859a