### PR TITLE
Add sequential DAG orchestrator with tool registry and CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - run: pip install . pytest ruff
+      - run: ruff .
+      - run: pytest -q

--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ python examples/run_hello.py
 Spin up FastAPI stubs for extract/link/verify/write. Run a Plan IR YAML.
 Output: JSON KG with provenance.
 
+```bash
+python -m micrographonia.sdk.cli plan.run \
+  --plan examples/manual_plans/notes.yml \
+  --context examples/datasets/note.json \
+  --registry registry/manifests
+```
+
 ---
 
 ## Roadmap

--- a/examples/datasets/note.json
+++ b/examples/datasets/note.json
@@ -1,0 +1,3 @@
+{
+  "text": "Met with Divya to discuss the demo. Follow up: Build a demo repo."
+}

--- a/examples/manual_plans/notes.yml
+++ b/examples/manual_plans/notes.yml
@@ -1,0 +1,30 @@
+version: "0.1"
+graph:
+  - id: extract
+    tool: extractor_A.v1
+    inputs:
+      text: "${context.text}"
+    out:
+      mentions: "$.mentions"
+  - id: link
+    tool: entity_linker.v1
+    needs: [extract]
+    inputs:
+      mentions: "${extract.mentions}"
+    out:
+      entities: "$.entities"
+  - id: verify
+    tool: verifier.v1
+    needs: [link]
+    inputs:
+      entities: "${link.entities}"
+    out:
+      triples: "$.triples"
+  - id: write
+    tool: kg_writer.v1
+    needs: [verify]
+    inputs:
+      triples: "${verify.triples}"
+      path: "${context.run_output}/kg.json"
+    out:
+      path: "$.path"

--- a/micrographonia/registry/manifest.py
+++ b/micrographonia/registry/manifest.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class ToolManifest:
+    """Description of a tool available in the registry."""
+
+    name: str
+    version: str
+    kind: str  # "http" or "inproc"
+    input_schema: Dict[str, Any]
+    output_schema: Dict[str, Any]
+    endpoint: Optional[str] = None
+    tags: list[str] | None = None
+
+    @property
+    def fqdn(self) -> str:
+        """Return name.version string."""
+
+        return f"{self.name}.{self.version}"

--- a/micrographonia/registry/registry.py
+++ b/micrographonia/registry/registry.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from jsonschema import Draft7Validator
+
+from .manifest import ToolManifest
+from ..runtime.errors import RegistryError
+
+
+class Registry:
+    """Load and resolve tool manifests."""
+
+    def __init__(self, root: str | Path):
+        self.root = Path(root)
+        self._manifests: Dict[str, ToolManifest] = {}
+        self._load()
+
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        if not self.root.exists():
+            raise RegistryError(f"registry dir {self.root} does not exist")
+
+        for path in self.root.glob("*.json"):
+            data = json.loads(path.read_text())
+            manifest = ToolManifest(**data)
+            key = manifest.fqdn
+            if key in self._manifests:
+                raise RegistryError(f"duplicate manifest for {key}")
+            if manifest.kind == "http":
+                if not manifest.endpoint or not manifest.endpoint.startswith("http"):
+                    raise RegistryError(f"http tool {key} missing valid endpoint")
+            Draft7Validator.check_schema(manifest.input_schema)
+            Draft7Validator.check_schema(manifest.output_schema)
+            self._manifests[key] = manifest
+
+    # ------------------------------------------------------------------
+    def resolve(self, fqdn: str) -> ToolManifest:
+        try:
+            return self._manifests[fqdn]
+        except KeyError as exc:  # pragma: no cover - simple mapping
+            raise RegistryError(f"unknown tool {fqdn}") from exc
+
+    # ------------------------------------------------------------------
+    def summary(self) -> Dict[str, Dict[str, Any]]:
+        return {key: {"kind": m.kind} for key, m in self._manifests.items()}
+
+    # ------------------------------------------------------------------
+    def health(self, base_url: str | None = None) -> Dict[str, bool]:
+        import httpx
+
+        results: Dict[str, bool] = {}
+        for key, manifest in self._manifests.items():
+            if manifest.kind == "http" and manifest.endpoint:
+                url = manifest.endpoint
+                if base_url:
+                    url = url.replace("http://localhost", base_url.rstrip("/"))
+                try:
+                    resp = httpx.get(f"{url}/health", timeout=2.0)
+                    results[key] = resp.status_code == 200
+                except Exception:  # pragma: no cover - network issues
+                    results[key] = False
+            else:
+                results[key] = True
+        return results

--- a/micrographonia/runtime/artifacts.py
+++ b/micrographonia/runtime/artifacts.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from pathlib import Path
+from typing import Any, Dict
+from uuid import uuid4
+
+from ..sdk.plan_ir import Plan
+
+
+class RunArtifacts:
+    """Helper for writing run artifacts to disk."""
+
+    def __init__(self, root: str | Path = "runs") -> None:
+        self.root_base = Path(root)
+        date_dir = _dt.date.today().isoformat()
+        self.run_id = uuid4().hex[:8]
+        self.root = self.root_base / date_dir / self.run_id
+        self.nodes_dir = self.root / "nodes"
+        self.output_dir = self.root / "outputs"
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.nodes_dir.mkdir(parents=True, exist_ok=True)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.paths: Dict[str, Any] = {"root": str(self.root), "nodes": {}}
+
+    # ------------------------------------------------------------------
+    def _write(self, path: Path, data: Any) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, ensure_ascii=False)
+
+    # ------------------------------------------------------------------
+    def write_plan(self, plan: Plan) -> None:
+        from dataclasses import asdict
+
+        path = self.root / "plan.json"
+        self._write(path, asdict(plan))
+        self.paths["plan"] = str(path)
+
+    def write_context(self, context: Dict[str, Any]) -> None:
+        path = self.root / "context.json"
+        self._write(path, context)
+        self.paths["context"] = str(path)
+
+    def write_node_request(self, node_id: str, tool: str, payload: Dict[str, Any]) -> None:
+        path = self.nodes_dir / f"{node_id}.request.json"
+        self._write(path, {"tool": tool, "payload": payload})
+        self.paths["nodes"].setdefault(node_id, {})["request"] = str(path)
+
+    def write_node_response(self, node_id: str, tool: str, data: Dict[str, Any], ms: int) -> None:
+        path = self.nodes_dir / f"{node_id}.response.json"
+        self._write(path, {"tool": tool, "data": data, "ms": ms})
+        self.paths["nodes"].setdefault(node_id, {})["response"] = str(path)
+
+    def write_node_error(self, node_id: str, message: str) -> None:
+        path = self.nodes_dir / f"{node_id}.error.json"
+        self._write(path, {"error": message})
+        self.paths["nodes"].setdefault(node_id, {})["error"] = str(path)
+
+    def write_metrics(self, metrics: Dict[str, Any]) -> None:
+        path = self.root / "metrics.json"
+        self._write(path, metrics)
+        self.paths["metrics"] = str(path)

--- a/micrographonia/runtime/engine.py
+++ b/micrographonia/runtime/engine.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Callable, Dict
+
+from ..sdk.plan_ir import Plan
+from ..registry.registry import Registry
+from .artifacts import RunArtifacts
+from .errors import BudgetError, EngineError, SchemaError, ToolCallError
+from .state import State, interpolate, extract_jsonpath
+from .tools import HttpTool, InprocTool, Tool
+
+
+def run_plan(
+    plan: Plan,
+    context: Dict,
+    registry: Registry,
+    impls: Dict[str, Callable[[dict], dict]] | None = None,
+    runs_dir: str | Path = "runs",
+) -> Dict:
+    """Execute *plan* sequentially."""
+
+    artifacts = RunArtifacts(runs_dir)
+    state = State(context, plan.vars)
+    state["context"]["run_output"] = str(artifacts.output_dir)
+    artifacts.write_plan(plan)
+    artifacts.write_context(state["context"])
+
+    metrics: Dict[str, Dict] = {"tool_calls": 0, "per_node": {}}
+    start = time.perf_counter()
+    ok = True
+    last_id = None
+
+    for node in plan.graph:
+        last_id = node.id
+        if plan.budget and plan.budget.max_tool_calls is not None:
+            if metrics["tool_calls"] >= plan.budget.max_tool_calls:
+                artifacts.write_node_error(node.id, "budget exceeded")
+                raise BudgetError("max tool calls exceeded")
+
+        inputs = interpolate(node.inputs, state)
+        manifest = registry.resolve(node.tool)
+        if manifest.kind == "http":
+            tool: Tool = HttpTool(manifest)
+        else:
+            if not impls or manifest.fqdn not in impls:
+                raise EngineError(f"missing implementation for {manifest.fqdn}")
+            tool = InprocTool(manifest, impls[manifest.fqdn])
+
+        artifacts.write_node_request(node.id, node.tool, inputs)
+        node_start = time.perf_counter()
+        try:
+            response = tool.invoke(inputs)
+        except (ToolCallError, SchemaError) as exc:
+            ok = False
+            artifacts.write_node_error(node.id, str(exc))
+            metrics["per_node"][node.id] = {
+                "ms": int((time.perf_counter() - node_start) * 1000),
+                "ok": False,
+            }
+            break
+
+        node_ms = int((time.perf_counter() - node_start) * 1000)
+        artifacts.write_node_response(node.id, node.tool, response, node_ms)
+        metrics["per_node"][node.id] = {"ms": node_ms, "ok": True}
+        metrics["tool_calls"] += 1
+
+        expose = {}
+        if node.out:
+            for key, path in node.out.items():
+                expose[key] = extract_jsonpath(response, path)
+        else:
+            expose = response
+        state["nodes"][node.id] = expose
+
+    total_ms = int((time.perf_counter() - start) * 1000)
+    metrics["total_ms"] = total_ms
+    artifacts.write_metrics(metrics)
+    return {
+        "run_id": artifacts.run_id,
+        "ok": ok,
+        "metrics": metrics,
+        "paths": artifacts.paths,
+        "state_tail": state["nodes"].get(last_id, {}),
+    }

--- a/micrographonia/runtime/errors.py
+++ b/micrographonia/runtime/errors.py
@@ -1,0 +1,49 @@
+"""Error taxonomy used across the runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+class MicrographiaError(Exception):
+    """Base class for all custom exceptions."""
+
+
+class PlanSchemaError(MicrographiaError):
+    """Raised when a plan fails validation."""
+
+
+class RegistryError(MicrographiaError):
+    """Raised for registry loading or lookup failures."""
+
+
+class SchemaError(MicrographiaError):
+    """Input or output payload failed JSON-schema validation."""
+
+    def __init__(self, message: str, errors: Any | None = None):
+        super().__init__(message)
+        self.errors = errors
+
+
+@dataclass
+class ToolCallError(MicrographiaError):
+    """Error during tool invocation."""
+
+    status: int | None
+    body: Any | None = None
+    message: str | None = None
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        base = self.message or "tool call failed"
+        if self.status is not None:
+            base += f" (status={self.status})"
+        return base
+
+
+class BudgetError(MicrographiaError):
+    """Raised when the execution budget is exceeded."""
+
+
+class EngineError(MicrographiaError):
+    """Raised for unexpected errors within the engine."""

--- a/micrographonia/runtime/state.py
+++ b/micrographonia/runtime/state.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+REF_RE = re.compile(r"\$\{([^}]+)\}")
+
+
+class State(Dict[str, Any]):
+    """Runtime state used for interpolation."""
+
+    def __init__(self, context: Dict[str, Any], vars: Dict[str, Any]):
+        super().__init__()
+        self["context"] = context
+        self["vars"] = vars
+        self["nodes"] = {}
+
+
+def _resolve_expr(expr: str, state: State) -> Any:
+    parts = expr.split(".")
+    if parts[0] == "context":
+        target = state["context"]
+        parts = parts[1:]
+    elif parts[0] == "vars":
+        target = state["vars"]
+        parts = parts[1:]
+    else:
+        if parts[0] not in state["nodes"]:
+            raise KeyError(expr)
+        target = state["nodes"][parts[0]]
+        parts = parts[1:]
+    for part in parts:
+        if isinstance(target, dict):
+            target = target[part]
+        else:
+            raise KeyError(expr)
+    return target
+
+
+def interpolate(value: Any, state: State) -> Any:
+    """Recursively replace ${} references in *value* using *state*."""
+
+    if isinstance(value, dict):
+        return {k: interpolate(v, state) for k, v in value.items()}
+    if isinstance(value, list):
+        return [interpolate(v, state) for v in value]
+    if isinstance(value, str):
+        match = REF_RE.fullmatch(value)
+        if match:
+            return _resolve_expr(match.group(1), state)
+        return REF_RE.sub(lambda m: str(_resolve_expr(m.group(1), state)), value)
+    return value
+
+
+def extract_jsonpath(data: Dict[str, Any], path: str) -> Any:
+    """Very small subset of JSONPath used in plan ``out`` mappings."""
+
+    if not path.startswith("$."):
+        raise KeyError(path)
+    cur: Any = data
+    parts = path[2:].split(".")
+    for part in parts:
+        if "[" in part and part.endswith("]"):
+            name, idx = part[:-1].split("[")
+            if name:
+                cur = cur[name]
+            cur = cur[int(idx)]
+        else:
+            cur = cur[part]
+    return cur

--- a/micrographonia/runtime/tools.py
+++ b/micrographonia/runtime/tools.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Callable, Protocol
+
+import httpx
+from jsonschema import Draft7Validator, ValidationError
+
+from ..registry.manifest import ToolManifest
+from .errors import SchemaError, ToolCallError
+
+
+class Tool(Protocol):
+    """Tool protocol."""
+
+    manifest: ToolManifest
+
+    def invoke(self, payload: dict, timeout_s: float | None = None) -> dict: ...
+
+
+class HttpTool:
+    """Invoke tools exposed over HTTP."""
+
+    def __init__(self, manifest: ToolManifest):
+        self.manifest = manifest
+        self._in_validator = Draft7Validator(manifest.input_schema)
+        self._out_validator = Draft7Validator(manifest.output_schema)
+
+    def invoke(self, payload: dict, timeout_s: float | None = None) -> dict:
+        try:
+            self._in_validator.validate(payload)
+        except ValidationError as exc:
+            raise SchemaError(f"input schema error: {exc.message}") from exc
+
+        try:
+            resp = httpx.post(self.manifest.endpoint, json=payload, timeout=timeout_s)
+        except httpx.HTTPError as exc:
+            raise ToolCallError(status=None, message=str(exc)) from exc
+        if resp.status_code >= 400:
+            raise ToolCallError(status=resp.status_code, body=resp.text)
+
+        data = resp.json()
+        try:
+            self._out_validator.validate(data)
+        except ValidationError as exc:
+            raise SchemaError(f"output schema error: {exc.message}") from exc
+        return data
+
+
+class InprocTool:
+    """Wrap a Python callable as a tool."""
+
+    def __init__(self, manifest: ToolManifest, func: Callable[[dict], dict]):
+        self.manifest = manifest
+        self.func = func
+        self._in_validator = Draft7Validator(manifest.input_schema)
+        self._out_validator = Draft7Validator(manifest.output_schema)
+
+    def invoke(self, payload: dict, timeout_s: float | None = None) -> dict:  # pragma: no cover - timeout unused
+        try:
+            self._in_validator.validate(payload)
+        except ValidationError as exc:
+            raise SchemaError(f"input schema error: {exc.message}") from exc
+        data = self.func(payload)
+        try:
+            self._out_validator.validate(data)
+        except ValidationError as exc:
+            raise SchemaError(f"output schema error: {exc.message}") from exc
+        return data

--- a/micrographonia/sdk/cli.py
+++ b/micrographonia/sdk/cli.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+
+from .validate import load_plan, validate_plan
+from ..registry.registry import Registry
+from ..runtime.engine import run_plan
+
+app = typer.Typer()
+plan_app = typer.Typer()
+registry_app = typer.Typer()
+app.add_typer(plan_app, name="plan")
+app.add_typer(registry_app, name="registry")
+
+
+def _load_impls():
+    try:  # pragma: no cover - optional
+        from ..tools.stubs import extractor_A, entity_linker, verifier, kg_writer
+
+        return {
+            "extractor_A.v1": extractor_A.run,
+            "entity_linker.v1": entity_linker.run,
+            "verifier.v1": verifier.run,
+            "kg_writer.v1": kg_writer.run,
+        }
+    except Exception:  # pragma: no cover
+        return {}
+
+
+@plan_app.command("validate")
+def plan_validate(plan: Path, registry: Path) -> None:
+    reg = Registry(registry)
+    p = load_plan(plan)
+    validate_plan(p, reg)
+    typer.echo("ok")
+
+
+@plan_app.command("run")
+def plan_run(
+    plan: Path,
+    context: Path,
+    registry: Path,
+    runs: Path = Path("runs"),
+    deadline_ms: int | None = None,
+) -> None:
+    reg = Registry(registry)
+    p = load_plan(plan)
+    validate_plan(p, reg)
+    ctx = json.loads(Path(context).read_text())
+    record = run_plan(p, ctx, reg, impls=_load_impls(), runs_dir=runs)
+    typer.echo(json.dumps(record, indent=2))
+
+
+@registry_app.command("health")
+def registry_health(registry: Path, base_url: str | None = None) -> None:
+    reg = Registry(registry)
+    result = reg.health(base_url)
+    typer.echo(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/micrographonia/sdk/plan_ir.py
+++ b/micrographonia/sdk/plan_ir.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Budget:
+    """Budget constraints for a plan."""
+
+    max_tool_calls: Optional[int] = None
+    deadline_ms: Optional[int] = None
+    max_parallel: Optional[int] = None
+
+
+@dataclass
+class Node:
+    """A single node in the execution graph."""
+
+    id: str
+    tool: str
+    inputs: Dict[str, Any]
+    needs: List[str] | None = None
+    out: Dict[str, str] | None = None
+
+
+@dataclass
+class Plan:
+    """Plan intermediate representation."""
+
+    version: str
+    graph: List[Node]
+    vars: Dict[str, Any] = field(default_factory=dict)
+    budget: Optional[Budget] = None

--- a/micrographonia/sdk/schemas/plan_ir.schema.json
+++ b/micrographonia/sdk/schemas/plan_ir.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["version", "graph"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {"type": "string", "const": "0.1"},
+    "vars": {"type": "object", "default": {}},
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_tool_calls": {"type": "integer", "minimum": 0},
+        "deadline_ms": {"type": "integer", "minimum": 0},
+        "max_parallel": {"type": "integer", "minimum": 1}
+      }
+    },
+    "graph": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "tool", "inputs"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {"type": "string"},
+          "tool": {"type": "string"},
+          "needs": {
+            "type": "array",
+            "items": {"type": "string"}
+          },
+          "inputs": {"type": "object"},
+          "out": {
+            "type": "object",
+            "additionalProperties": {"type": "string"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/micrographonia/sdk/validate.py
+++ b/micrographonia/sdk/validate.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Set
+
+import yaml
+from jsonschema import Draft7Validator
+
+from .plan_ir import Plan, Node, Budget
+from ..registry.registry import Registry
+from ..runtime.errors import PlanSchemaError
+
+SCHEMA_PATH = Path(__file__).parent / "schemas" / "plan_ir.schema.json"
+SCHEMA = json.loads(SCHEMA_PATH.read_text())
+VALIDATOR = Draft7Validator(SCHEMA)
+
+
+def load_plan(path: str | Path) -> Plan:
+    """Load a plan from YAML or JSON and return a :class:`Plan`."""
+
+    path = Path(path)
+    data = json.loads(path.read_text()) if path.suffix == ".json" else yaml.safe_load(path.read_text())
+    VALIDATOR.validate(data)
+    return _from_dict(data)
+
+
+def _from_dict(data: Dict) -> Plan:
+    budget = data.get("budget")
+    budget_obj = Budget(**budget) if budget else None
+    nodes = [Node(**n) for n in data["graph"]]
+    return Plan(version=data["version"], vars=data.get("vars", {}), budget=budget_obj, graph=nodes)
+
+
+def validate_plan(plan: Plan, registry: Registry) -> None:
+    """Validate structural rules for the plan against a registry."""
+
+    node_ids: Set[str] = set()
+    for node in plan.graph:
+        if node.id in node_ids:
+            raise PlanSchemaError(f"duplicate node id {node.id}")
+        node_ids.add(node.id)
+        try:
+            registry.resolve(node.tool)
+        except Exception as exc:
+            raise PlanSchemaError(f"unknown tool {node.tool}") from exc
+
+    # needs references exist and DAG acyclic
+    edges = {node.id: node.needs or [] for node in plan.graph}
+    _check_acyclic(edges)
+
+
+def _check_acyclic(edges: Dict[str, List[str]]) -> None:
+    temp: Set[str] = set()
+    perm: Set[str] = set()
+
+    def visit(n: str) -> None:
+        if n in perm:
+            return
+        if n in temp:
+            raise PlanSchemaError("graph contains a cycle")
+        temp.add(n)
+        for m in edges.get(n, []):
+            if m not in edges:
+                raise PlanSchemaError(f"unknown dependency {m}")
+            visit(m)
+        temp.remove(n)
+        perm.add(n)
+
+    for node in edges:
+        visit(node)

--- a/micrographonia/tools/stubs/__init__.py
+++ b/micrographonia/tools/stubs/__init__.py
@@ -1,0 +1,6 @@
+from .extractor_A import run as extractor_A
+from .entity_linker import run as entity_linker
+from .verifier import run as verifier
+from .kg_writer import run as kg_writer
+
+__all__ = ["extractor_A", "entity_linker", "verifier", "kg_writer"]

--- a/micrographonia/tools/stubs/entity_linker.py
+++ b/micrographonia/tools/stubs/entity_linker.py
@@ -1,0 +1,3 @@
+def run(payload: dict) -> dict:
+    entities = [{"mention": m, "entity": m.lower()} for m in payload["mentions"]]
+    return {"entities": entities}

--- a/micrographonia/tools/stubs/extractor_A.py
+++ b/micrographonia/tools/stubs/extractor_A.py
@@ -1,0 +1,4 @@
+def run(payload: dict) -> dict:
+    text: str = payload["text"]
+    mentions = [w for w in text.split() if w and w[0].isupper()]
+    return {"mentions": mentions}

--- a/micrographonia/tools/stubs/kg_writer.py
+++ b/micrographonia/tools/stubs/kg_writer.py
@@ -1,0 +1,9 @@
+import json
+from pathlib import Path
+
+def run(payload: dict) -> dict:
+    path = Path(payload.get("path", "kg.json"))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump({"triples": payload["triples"]}, fh, indent=2)
+    return {"path": str(path)}

--- a/micrographonia/tools/stubs/verifier.py
+++ b/micrographonia/tools/stubs/verifier.py
@@ -1,0 +1,3 @@
+def run(payload: dict) -> dict:
+    triples = [[e["entity"], "is", e["mention"]] for e in payload["entities"]]
+    return {"triples": triples}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,13 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+    "jsonschema>=4.17",
+    "httpx>=0.25",
+    "typer>=0.9",
+    "pyyaml>=6.0",
+]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"

--- a/registry/manifests/entity_linker.v1.json
+++ b/registry/manifests/entity_linker.v1.json
@@ -1,0 +1,32 @@
+{
+  "name": "entity_linker",
+  "version": "v1",
+  "kind": "inproc",
+  "input_schema": {
+    "type": "object",
+    "required": ["mentions"],
+    "properties": {
+      "mentions": {"type": "array", "items": {"type": "string"}}
+    },
+    "additionalProperties": false
+  },
+  "output_schema": {
+    "type": "object",
+    "required": ["entities"],
+    "properties": {
+      "entities": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["mention", "entity"],
+          "properties": {
+            "mention": {"type": "string"},
+            "entity": {"type": "string"}
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/registry/manifests/extractor_A.v1.json
+++ b/registry/manifests/extractor_A.v1.json
@@ -1,0 +1,19 @@
+{
+  "name": "extractor_A",
+  "version": "v1",
+  "kind": "inproc",
+  "input_schema": {
+    "type": "object",
+    "required": ["text"],
+    "properties": {"text": {"type": "string"}},
+    "additionalProperties": false
+  },
+  "output_schema": {
+    "type": "object",
+    "required": ["mentions"],
+    "properties": {
+      "mentions": {"type": "array", "items": {"type": "string"}}
+    },
+    "additionalProperties": false
+  }
+}

--- a/registry/manifests/kg_writer.v1.json
+++ b/registry/manifests/kg_writer.v1.json
@@ -1,0 +1,28 @@
+{
+  "name": "kg_writer",
+  "version": "v1",
+  "kind": "inproc",
+  "input_schema": {
+    "type": "object",
+    "required": ["triples", "path"],
+    "properties": {
+      "triples": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 3,
+          "maxItems": 3
+        }
+      },
+      "path": {"type": "string"}
+    },
+    "additionalProperties": false
+  },
+  "output_schema": {
+    "type": "object",
+    "required": ["path"],
+    "properties": {"path": {"type": "string"}},
+    "additionalProperties": false
+  }
+}

--- a/registry/manifests/verifier.v1.json
+++ b/registry/manifests/verifier.v1.json
@@ -1,0 +1,40 @@
+{
+  "name": "verifier",
+  "version": "v1",
+  "kind": "inproc",
+  "input_schema": {
+    "type": "object",
+    "required": ["entities"],
+    "properties": {
+      "entities": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["mention", "entity"],
+          "properties": {
+            "mention": {"type": "string"},
+            "entity": {"type": "string"}
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "additionalProperties": false
+  },
+  "output_schema": {
+    "type": "object",
+    "required": ["triples"],
+    "properties": {
+      "triples": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 3,
+          "maxItems": 3
+        }
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_engine_smoke.py
+++ b/tests/test_engine_smoke.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from micrographonia.registry.registry import Registry
+from micrographonia.sdk.validate import load_plan, validate_plan
+from micrographonia.runtime.engine import run_plan
+from micrographonia.tools.stubs import extractor_A, entity_linker, kg_writer, verifier
+
+REG_DIR = Path("registry/manifests")
+PLAN_PATH = Path("examples/manual_plans/notes.yml")
+CTX_PATH = Path("examples/datasets/note.json")
+
+IMPLS = {
+    "extractor_A.v1": extractor_A,
+    "entity_linker.v1": entity_linker,
+    "verifier.v1": verifier,
+    "kg_writer.v1": kg_writer,
+}
+
+
+def test_engine_run(tmp_path: Path) -> None:
+    reg = Registry(REG_DIR)
+    plan = load_plan(PLAN_PATH)
+    validate_plan(plan, reg)
+    ctx = json.loads(CTX_PATH.read_text())
+    record = run_plan(plan, ctx, reg, impls=IMPLS, runs_dir=tmp_path)
+    assert record["ok"] is True
+    assert record["metrics"]["tool_calls"] == 4
+    out_path = Path(record["state_tail"]["path"])
+    assert out_path.exists()
+
+
+def test_engine_failure(tmp_path: Path) -> None:
+    reg = Registry(REG_DIR)
+    plan = load_plan(PLAN_PATH)
+    validate_plan(plan, reg)
+    ctx = json.loads(CTX_PATH.read_text())
+    bad_impls = dict(IMPLS)
+    bad_impls["entity_linker.v1"] = lambda p: {}
+    record = run_plan(plan, ctx, reg, impls=bad_impls, runs_dir=tmp_path)
+    assert record["ok"] is False
+    node_err = record["paths"]["nodes"]["link"]["error"]
+    assert Path(node_err).exists()

--- a/tests/test_plan_validation.py
+++ b/tests/test_plan_validation.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from micrographonia.registry.registry import Registry
+from micrographonia.runtime.errors import PlanSchemaError
+from micrographonia.sdk.validate import load_plan, validate_plan
+
+REG_DIR = Path("registry/manifests")
+PLAN_PATH = Path("examples/manual_plans/notes.yml")
+
+
+def test_valid_plan() -> None:
+    reg = Registry(REG_DIR)
+    plan = load_plan(PLAN_PATH)
+    validate_plan(plan, reg)
+
+
+def _write_plan(tmp_path: Path, data: dict) -> Path:
+    path = tmp_path / "plan.yml"
+    path.write_text(yaml.safe_dump(data))
+    return path
+
+
+def test_duplicate_id(tmp_path: Path) -> None:
+    reg = Registry(REG_DIR)
+    data = yaml.safe_load(PLAN_PATH.read_text())
+    data["graph"][1]["id"] = "extract"  # duplicate
+    path = _write_plan(tmp_path, data)
+    plan = load_plan(path)
+    with pytest.raises(PlanSchemaError):
+        validate_plan(plan, reg)
+
+
+def test_unknown_tool(tmp_path: Path) -> None:
+    reg = Registry(REG_DIR)
+    data = yaml.safe_load(PLAN_PATH.read_text())
+    data["graph"][0]["tool"] = "missing.v1"
+    path = _write_plan(tmp_path, data)
+    plan = load_plan(path)
+    with pytest.raises(PlanSchemaError):
+        validate_plan(plan, reg)
+
+
+def test_cycle(tmp_path: Path) -> None:
+    reg = Registry(REG_DIR)
+    data = yaml.safe_load(PLAN_PATH.read_text())
+    data["graph"][0]["needs"] = ["write"]
+    path = _write_plan(tmp_path, data)
+    plan = load_plan(path)
+    with pytest.raises(PlanSchemaError):
+        validate_plan(plan, reg)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from micrographonia.registry.registry import Registry
+from micrographonia.runtime.errors import RegistryError
+
+REG_DIR = Path("registry/manifests")
+
+
+def test_registry_summary() -> None:
+    reg = Registry(REG_DIR)
+    summary = reg.summary()
+    assert "extractor_A.v1" in summary
+    assert summary["kg_writer.v1"]["kind"] == "inproc"
+
+
+def test_bad_manifest(tmp_path: Path) -> None:
+    bad = {
+        "name": "bad",
+        "version": "v1",
+        "kind": "http",
+        "input_schema": {},
+        "output_schema": {},
+    }
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(bad))
+    with pytest.raises(RegistryError):
+        Registry(tmp_path)

--- a/tests/test_state_interpolation.py
+++ b/tests/test_state_interpolation.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from micrographonia.runtime.state import State, interpolate
+
+
+def test_interpolation() -> None:
+    state = State({"foo": "bar"}, {"x": 1})
+    state["nodes"]["n1"] = {"a": 2}
+    data = {"a": "${context.foo}", "b": "${vars.x}", "c": "${n1.a}"}
+    assert interpolate(data, state) == {"a": "bar", "b": 1, "c": 2}
+
+
+def test_missing_ref() -> None:
+    state = State({}, {})
+    with pytest.raises(KeyError):
+        interpolate("${unknown}", state)

--- a/tests/test_tools_http_inproc.py
+++ b/tests/test_tools_http_inproc.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from micrographonia.registry.manifest import ToolManifest
+from micrographonia.runtime.errors import SchemaError, ToolCallError
+from micrographonia.runtime.tools import HttpTool, InprocTool
+
+
+def test_inproc_tool_validation() -> None:
+    manifest = ToolManifest(
+        name="adder",
+        version="v1",
+        kind="inproc",
+        input_schema={
+            "type": "object",
+            "required": ["a"],
+            "properties": {"a": {"type": "integer"}},
+            "additionalProperties": False,
+        },
+        output_schema={
+            "type": "object",
+            "required": ["b"],
+            "properties": {"b": {"type": "integer"}},
+            "additionalProperties": False,
+        },
+    )
+
+    tool = InprocTool(manifest, lambda p: {"b": p["a"] + 1})
+    assert tool.invoke({"a": 1}) == {"b": 2}
+    with pytest.raises(SchemaError):
+        tool.invoke({"a": "x"})
+    bad_tool = InprocTool(manifest, lambda p: {})
+    with pytest.raises(SchemaError):
+        bad_tool.invoke({"a": 1})
+
+
+def test_http_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = ToolManifest(
+        name="remote",
+        version="v1",
+        kind="http",
+        endpoint="http://test/tool",
+        input_schema={"type": "object", "properties": {}, "additionalProperties": True},
+        output_schema={
+            "type": "object",
+            "required": ["x"],
+            "properties": {"x": {"type": "integer"}},
+            "additionalProperties": False,
+        },
+    )
+    tool = HttpTool(manifest)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"x": 5})
+
+    transport = httpx.MockTransport(handler)
+
+    def fake_post(url: str, json: dict, timeout: float | None = None) -> httpx.Response:
+        client = httpx.Client(transport=transport)
+        return client.post(url, json=json)
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    assert tool.invoke({}) == {"x": 5}
+
+    def bad_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={})
+
+    transport_bad = httpx.MockTransport(bad_handler)
+
+    def bad_post(url: str, json: dict, timeout: float | None = None) -> httpx.Response:
+        client = httpx.Client(transport=transport_bad)
+        return client.post(url, json=json)
+
+    monkeypatch.setattr(httpx, "post", bad_post)
+    with pytest.raises(SchemaError):
+        tool.invoke({})
+
+    def err_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={})
+
+    transport_err = httpx.MockTransport(err_handler)
+
+    def err_post(url: str, json: dict, timeout: float | None = None) -> httpx.Response:
+        client = httpx.Client(transport=transport_err)
+        return client.post(url, json=json)
+
+    monkeypatch.setattr(httpx, "post", err_post)
+    with pytest.raises(ToolCallError):
+        tool.invoke({})


### PR DESCRIPTION
## Summary
- implement Plan IR dataclasses and validation against JSON schema
- add tool registry with manifest loader and health checks
- build sequential runtime engine with state interpolation and artifact persistence
- provide stub tools, manifests, example plan and datasets
- expose Typer CLI and comprehensive tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4d8dcc384832680d797389e35e8f5