### PR TITLE
Enforce DAG dependencies and deadlines in runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,14 @@ python -m micrographonia.sdk.cli plan.run \
   --registry registry/manifests
 ```
 
+Validate a plan without running it:
+
+```bash
+python -m micrographonia.sdk.cli plan.validate \
+  --plan examples/manual_plans/notes.yml \
+  --registry registry/manifests
+```
+
 ---
 
 ## Roadmap

--- a/tests/test_engine_budget_deadline.py
+++ b/tests/test_engine_budget_deadline.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from micrographonia.registry.registry import Registry
+from micrographonia.sdk.plan_ir import Plan, Node, Budget
+from micrographonia.runtime.engine import run_plan
+from micrographonia.runtime.errors import BudgetError
+
+REG_DIR = Path("registry/manifests")
+
+
+def slow_extract(payload: dict) -> dict:
+    time.sleep(0.2)
+    return {"mentions": []}
+
+
+def test_deadline_budget(tmp_path: Path) -> None:
+    reg = Registry(REG_DIR)
+    node = Node(id="extract", tool="extractor_A.v1", inputs={"text": "hi"})
+    plan = Plan(version="0.1", graph=[node], budget=Budget(deadline_ms=50))
+    impls = {"extractor_A.v1": slow_extract}
+    with pytest.raises(BudgetError):
+        run_plan(plan, {}, reg, impls=impls, runs_dir=tmp_path)

--- a/tests/test_engine_needs_missing.py
+++ b/tests/test_engine_needs_missing.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from micrographonia.registry.registry import Registry
+from micrographonia.sdk.plan_ir import Plan, Node
+from micrographonia.runtime.engine import run_plan
+from micrographonia.tools.stubs import extractor_A, entity_linker
+
+REG_DIR = Path("registry/manifests")
+IMPLS = {
+    "extractor_A.v1": extractor_A,
+    "entity_linker.v1": entity_linker,
+}
+
+
+def test_missing_reference(tmp_path: Path) -> None:
+    reg = Registry(REG_DIR)
+    n1 = Node(id="extract", tool="extractor_A.v1", inputs={"text": "Hi"})
+    n2 = Node(
+        id="link",
+        tool="entity_linker.v1",
+        needs=["extract"],
+        inputs={"mentions": "${extract.missing}"},
+    )
+    plan = Plan(version="0.1", graph=[n1, n2])
+    record = run_plan(plan, {}, reg, impls=IMPLS, runs_dir=tmp_path)
+    assert record["ok"] is False
+    err_path = Path(record["paths"]["nodes"]["link"]["error"])
+    assert err_path.exists()

--- a/tests/test_state_interpolation.py
+++ b/tests/test_state_interpolation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from micrographonia.runtime.state import State, interpolate
+from micrographonia.runtime.errors import SchemaError
 
 
 def test_interpolation() -> None:
@@ -14,5 +15,5 @@ def test_interpolation() -> None:
 
 def test_missing_ref() -> None:
     state = State({}, {})
-    with pytest.raises(KeyError):
+    with pytest.raises(SchemaError):
         interpolate("${unknown}", state)


### PR DESCRIPTION
## Summary
- topo-sort plan graph and enforce `needs` dependencies before node execution
- add budget `deadline_ms` checks and improved interpolation errors
- provide stable CLI exit codes and document `plan.validate`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4dc0c94f08326b83c4edceae2188f