### PR TITLE
Add Gemini and OpenAI teacher API integrations

### DIFF
--- a/micrographonia/tools/__init__.py
+++ b/micrographonia/tools/__init__.py
@@ -3,6 +3,8 @@
 Each tool is intended to be replaced by a small specialized model.
 """
 
+from . import teachers
+
 class BaseTool:
     """Base class for tool stubs."""
 
@@ -12,3 +14,6 @@ class BaseTool:
         """Execute the tool with given arguments."""
         # TODO: implement tool behavior
         return {}
+
+
+__all__ = ["BaseTool", "teachers"]

--- a/micrographonia/tools/teachers/__init__.py
+++ b/micrographonia/tools/teachers/__init__.py
@@ -1,0 +1,6 @@
+"""LLM-backed teacher tools."""
+
+from .gemini import run as gemini
+from .oai import run as oai
+
+__all__ = ["gemini", "oai"]

--- a/micrographonia/tools/teachers/gemini.py
+++ b/micrographonia/tools/teachers/gemini.py
@@ -1,0 +1,39 @@
+"""Google Gemini teacher calling the Generative Language API."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
+
+
+def run(payload: dict) -> dict:
+    """Invoke Gemini with *prompt* and return the text response.
+
+    Args:
+        payload: mapping with at least a ``prompt`` key and optional ``model``.
+
+    Returns:
+        dict: ``{"text": <response>}``
+    """
+
+    prompt = payload["prompt"]
+    model = payload.get("model", "gemini-pro")
+    api_key = os.environ["GEMINI_API_KEY"]
+
+    url = _API_URL.format(model=model)
+    params = {"key": api_key}
+    json_payload = {"contents": [{"parts": [{"text": prompt}]}]}
+
+    response = httpx.post(url, params=params, json=json_payload, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+
+    try:
+        text = data["candidates"][0]["content"]["parts"][0]["text"]
+    except (KeyError, IndexError) as exc:  # pragma: no cover - defensive
+        raise RuntimeError("unexpected response format") from exc
+
+    return {"text": text}

--- a/micrographonia/tools/teachers/oai.py
+++ b/micrographonia/tools/teachers/oai.py
@@ -1,0 +1,34 @@
+"""OpenAI teacher calling the Chat Completions API."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+_API_URL = "https://api.openai.com/v1/chat/completions"
+
+
+def run(payload: dict) -> dict:
+    """Invoke OpenAI with *prompt* and return the text response."""
+
+    prompt = payload["prompt"]
+    model = payload.get("model", "gpt-4o-mini")
+    api_key = os.environ["OPENAI_API_KEY"]
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    json_payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+
+    response = httpx.post(_API_URL, headers=headers, json=json_payload, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+
+    try:
+        text = data["choices"][0]["message"]["content"]
+    except (KeyError, IndexError) as exc:  # pragma: no cover - defensive
+        raise RuntimeError("unexpected response format") from exc
+
+    return {"text": text}

--- a/tests/test_teachers.py
+++ b/tests/test_teachers.py
@@ -1,0 +1,56 @@
+from unittest.mock import patch
+
+from micrographonia.tools.teachers.gemini import run as gemini_run
+from micrographonia.tools.teachers.oai import run as oai_run
+
+
+def test_gemini_run(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+    def fake_post(url, params=None, json=None, timeout=None):
+        assert params["key"] == "test-key"
+        assert json["contents"][0]["parts"][0]["text"] == "hi"
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "candidates": [
+                        {"content": {"parts": [{"text": "hello"}]}}
+                    ]
+                }
+
+        return Resp()
+
+    with patch("httpx.post", side_effect=fake_post):
+        out = gemini_run({"prompt": "hi"})
+
+    assert out == {"text": "hello"}
+
+
+def test_oai_run(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        assert headers["Authorization"] == "Bearer test-key"
+        assert json["messages"][0]["content"] == "hi"
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "choices": [
+                        {"message": {"content": "hello"}}
+                    ]
+                }
+
+        return Resp()
+
+    with patch("httpx.post", side_effect=fake_post):
+        out = oai_run({"prompt": "hi"})
+
+    assert out == {"text": "hello"}


### PR DESCRIPTION
## Summary
- add Gemini teacher that calls Google Generative Language API using an API key from the environment
- add OpenAI teacher using Chat Completions endpoint and expose teachers via tools package
- cover teacher APIs with unit tests mocking HTTP calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4ded8e7d0832684d625f9bdf3f160