### PR TITLE
Add retry, caching, and concurrency scaffolding

### DIFF
--- a/micrographonia/runtime/cache.py
+++ b/micrographonia/runtime/cache.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def _stable_dumps(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def cache_key(
+    tool: str, version: str, inputs: Dict[str, Any], manifest_hash: str
+) -> str:
+    """Compute a deterministic cache key for a tool invocation."""
+    data = {
+        "tool": tool,
+        "version": version,
+        "inputs": inputs,
+        "manifest_hash": manifest_hash,
+    }
+    blob = _stable_dumps(data)
+    return hashlib.sha256(blob.encode()).hexdigest()
+
+
+class SimpleCache:
+    """Very small JSON-on-disk cache used for testing."""
+
+    def __init__(self, root: Path):
+        self.root = root
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def read(self, key: str) -> Any | None:
+        path = self.root / f"{key}.json"
+        if not path.exists():
+            return None
+        return json.loads(path.read_text())
+
+    def write(self, key: str, data: Any) -> None:
+        path = self.root / f"{key}.json"
+        path.write_text(_stable_dumps(data))

--- a/micrographonia/runtime/concurrency.py
+++ b/micrographonia/runtime/concurrency.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import Dict
+
+
+class ConcurrencyManager:
+    """Manage global and per-tool concurrency limits."""
+
+    def __init__(self, max_parallel: int):
+        self.global_sem = asyncio.Semaphore(max_parallel)
+        self._tool_limits: Dict[str, int] = {}
+        self._tool_sems: Dict[str, asyncio.Semaphore] = {}
+
+    def _get_tool_sem(self, tool: str, limit: int | None) -> asyncio.Semaphore:
+        if tool not in self._tool_sems:
+            if limit is None:
+                limit = 1_000_000  # effectively unbounded
+            self._tool_limits[tool] = limit
+            self._tool_sems[tool] = asyncio.Semaphore(limit)
+        return self._tool_sems[tool]
+
+    @asynccontextmanager
+    async def slot(self, tool: str, limit: int | None = None):
+        tool_sem = self._get_tool_sem(tool, limit)
+        async with self.global_sem, tool_sem:
+            yield

--- a/micrographonia/runtime/errors.py
+++ b/micrographonia/runtime/errors.py
@@ -21,9 +21,13 @@ class RegistryError(MicrographiaError):
 class SchemaError(MicrographiaError):
     """Input or output payload failed JSON-schema validation."""
 
-    def __init__(self, message: str, errors: Any | None = None):
+    def __init__(
+        self, message: str, errors: Any | None = None, stage: str | None = None
+    ) -> None:
         super().__init__(message)
         self.errors = errors
+        # stage is optional; when provided it typically indicates PRE/POST.
+        self.stage = stage
 
 
 @dataclass

--- a/micrographonia/runtime/retry.py
+++ b/micrographonia/runtime/retry.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from .errors import EngineError, SchemaError, ToolCallError
+
+
+@dataclass
+class _Rule:
+    exc_type: type
+    code: int | None = None
+    family: int | None = None
+    stage: str | None = None
+
+
+class RetryMatcher:
+    """Determine whether an exception should trigger a retry."""
+
+    _MAP = {
+        "ToolCallError": ToolCallError,
+        "SchemaError": SchemaError,
+        "EngineError": EngineError,
+    }
+
+    def __init__(self, patterns: Sequence[str]):
+        self.rules: List[_Rule] = [self._parse(p) for p in patterns]
+
+    def _parse(self, pattern: str) -> _Rule:
+        cls_name, _, spec = pattern.partition(":")
+        exc_type = self._MAP.get(cls_name)
+        if exc_type is None:
+            raise ValueError(f"unknown retry class {cls_name}")
+        code = family = None
+        stage = None
+        if spec:
+            if exc_type is ToolCallError:
+                if spec.endswith("xx") and len(spec) == 3:
+                    family = int(spec[0]) * 100
+                else:
+                    code = int(spec)
+            elif exc_type is SchemaError:
+                stage = spec
+        return _Rule(exc_type, code=code, family=family, stage=stage)
+
+    def matches(self, exc: Exception) -> bool:
+        for rule in self.rules:
+            if isinstance(exc, rule.exc_type):
+                if rule.exc_type is ToolCallError:
+                    status = getattr(exc, "status", None)
+                    if rule.code is not None and status != rule.code:
+                        continue
+                    if rule.family is not None and (
+                        status is None or status // 100 * 100 != rule.family
+                    ):
+                        continue
+                elif rule.exc_type is SchemaError and rule.stage is not None:
+                    if getattr(exc, "stage", None) != rule.stage:
+                        continue
+                return True
+        return False
+
+
+def backoff_delays(retries: int, backoff_ms: int, jitter_ms: int = 0) -> List[float]:
+    """Compute the sequence of backoff delays in milliseconds."""
+    delays: List[float] = []
+    for attempt in range(retries):
+        base = backoff_ms * (2 ** attempt)
+        jitter = random.uniform(0, jitter_ms) if jitter_ms else 0
+        delays.append(base + jitter)
+    return delays

--- a/micrographonia/sdk/plan_ir.py
+++ b/micrographonia/sdk/plan_ir.py
@@ -10,7 +10,6 @@ class Budget:
 
     max_tool_calls: Optional[int] = None
     deadline_ms: Optional[int] = None
-    max_parallel: Optional[int] = None
 
 
 @dataclass
@@ -22,6 +21,25 @@ class Node:
     inputs: Dict[str, Any]
     needs: List[str] | None = None
     out: Dict[str, str] | None = None
+    cache: Optional[bool] = None
+    timeout_ms: Optional[int] = None
+    retry: Optional["RetryPolicy"] = None
+    concurrency: Optional[int] = None
+
+
+@dataclass
+class RetryPolicy:
+    retries: int = 0
+    backoff_ms: int = 0
+    jitter_ms: int = 0
+    retry_on: List[str] = field(default_factory=list)
+
+
+@dataclass
+class Execution:
+    max_parallel: Optional[int] = None
+    cache_default: Optional[bool] = None
+    retry_default: Optional[RetryPolicy] = None
 
 
 @dataclass
@@ -32,3 +50,4 @@ class Plan:
     graph: List[Node]
     vars: Dict[str, Any] = field(default_factory=dict)
     budget: Optional[Budget] = None
+    execution: Optional[Execution] = None

--- a/micrographonia/sdk/schemas/plan_ir.schema.json
+++ b/micrographonia/sdk/schemas/plan_ir.schema.json
@@ -11,8 +11,18 @@
       "additionalProperties": false,
       "properties": {
         "max_tool_calls": {"type": "integer", "minimum": 0},
-        "deadline_ms": {"type": "integer", "minimum": 0},
-        "max_parallel": {"type": "integer", "minimum": 1}
+        "deadline_ms": {"type": "integer", "minimum": 0}
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_parallel": {"type": "integer", "minimum": 1},
+        "cache_default": {"type": "boolean"},
+        "retry_default": {
+          "$ref": "#/definitions/retry"
+        }
       }
     },
     "graph": {
@@ -32,7 +42,27 @@
           "out": {
             "type": "object",
             "additionalProperties": {"type": "string"}
-          }
+          },
+          "cache": {"type": "boolean"},
+          "timeout_ms": {"type": "integer", "minimum": 0},
+          "retry": {"$ref": "#/definitions/retry"},
+          "concurrency": {"type": "integer", "minimum": 1}
+        }
+      }
+    }
+  }
+  ,
+  "definitions": {
+    "retry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "retries": {"type": "integer", "minimum": 0},
+        "backoff_ms": {"type": "integer", "minimum": 0},
+        "jitter_ms": {"type": "integer", "minimum": 0},
+        "retry_on": {
+          "type": "array",
+          "items": {"type": "string"}
         }
       }
     }

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,11 @@
+from micrographonia.runtime.cache import cache_key
+
+
+def test_cache_key_stability() -> None:
+    key1 = cache_key("tool", "1", {"a": 1, "b": 2}, "mhash")
+    key2 = cache_key("tool", "1", {"b": 2, "a": 1}, "mhash")
+    key3 = cache_key("tool", "2", {"a": 1, "b": 2}, "mhash")
+    key4 = cache_key("tool", "1", {"a": 1, "b": 2}, "other")
+    assert key1 == key2
+    assert key1 != key3
+    assert key1 != key4

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,23 @@
+import asyncio
+
+from micrographonia.runtime.concurrency import ConcurrencyManager
+
+
+def test_concurrency_semaphores() -> None:
+    mgr = ConcurrencyManager(max_parallel=5)
+    running = 0
+    max_running = 0
+
+    async def worker():
+        nonlocal running, max_running
+        async with mgr.slot("tool", limit=2):
+            running += 1
+            max_running = max(max_running, running)
+            await asyncio.sleep(0.05)
+            running -= 1
+
+    async def main():
+        await asyncio.gather(*(worker() for _ in range(5)))
+
+    asyncio.run(main())
+    assert max_running <= 2

--- a/tests/test_plan_validation.py
+++ b/tests/test_plan_validation.py
@@ -53,3 +53,18 @@ def test_cycle(tmp_path: Path) -> None:
     plan = load_plan(path)
     with pytest.raises(PlanSchemaError):
         validate_plan(plan, reg)
+
+
+def test_invalid_execution_and_retry(tmp_path: Path) -> None:
+    reg = Registry(REG_DIR)
+    data = yaml.safe_load(PLAN_PATH.read_text())
+    data["execution"] = {"max_parallel": 0}
+    path = _write_plan(tmp_path, data)
+    with pytest.raises(PlanSchemaError):
+        load_plan(path)
+
+    data["execution"] = {"max_parallel": 1}
+    data["graph"][0]["retry"] = {"retries": -1}
+    path = _write_plan(tmp_path, data)
+    with pytest.raises(PlanSchemaError):
+        load_plan(path)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,14 @@
+from micrographonia.runtime.retry import RetryMatcher, backoff_delays
+from micrographonia.runtime.errors import ToolCallError, SchemaError
+
+
+def test_retry_matcher() -> None:
+    matcher = RetryMatcher(["ToolCallError:429", "ToolCallError:5xx"])
+    assert matcher.matches(ToolCallError(status=429))
+    assert matcher.matches(ToolCallError(status=502))
+    assert not matcher.matches(SchemaError("boom", stage="POST"))
+
+
+def test_backoff_sequence() -> None:
+    delays = backoff_delays(retries=3, backoff_ms=200, jitter_ms=0)
+    assert delays == [200, 400, 800]


### PR DESCRIPTION
## Summary
- introduce retry helper with pattern matching and exponential backoff
- add deterministic cache key and simple disk cache
- manage global/per-tool concurrency via semaphores
- extend Plan IR and schema for execution and retry options
- cover new behavior with tests for retry, backoff, cache key, concurrency, and schema validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e1ce2f1c83269cee741e7ac6dbf4