### PR TITLE
feat: add async engine with resume and cache

### DIFF
--- a/micrographonia/runtime/cache.py
+++ b/micrographonia/runtime/cache.py
@@ -25,18 +25,59 @@ def cache_key(
 
 
 class SimpleCache:
-    """Very small JSON-on-disk cache used for testing."""
+    """Very small JSON-on-disk cache used for testing.
 
-    def __init__(self, root: Path):
+    The implementation is intentionally tiny but includes a couple of
+    characteristics that are important for the runtime:
+
+    * Writes are atomic – data is written to a ``.tmp`` file and then
+      atomically renamed over the target path to avoid torn writes.
+    * A size cap (``max_bytes``) can be supplied; when the cache grows
+      beyond the limit the oldest entries are evicted in a basic LRU
+      manner.
+
+    The cache stores each entry as ``<key>.json`` containing a JSON
+    document.  Keys are assumed to already be content addressed.
+    """
+
+    def __init__(self, root: Path, max_bytes: int | None = None):
         self.root = root
+        self.max_bytes = max_bytes
         self.root.mkdir(parents=True, exist_ok=True)
 
+    # ------------------------------------------------------------------
+    def _path(self, key: str) -> Path:
+        return self.root / f"{key}.json"
+
+    # ------------------------------------------------------------------
     def read(self, key: str) -> Any | None:
-        path = self.root / f"{key}.json"
+        path = self._path(key)
         if not path.exists():
             return None
         return json.loads(path.read_text())
 
+    # ------------------------------------------------------------------
     def write(self, key: str, data: Any) -> None:
-        path = self.root / f"{key}.json"
-        path.write_text(_stable_dumps(data))
+        path = self._path(key)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(_stable_dumps(data))
+        tmp.replace(path)
+        if self.max_bytes is not None:
+            self._enforce_size()
+
+    # ------------------------------------------------------------------
+    def _enforce_size(self) -> None:
+        """Delete oldest files until the cache fits ``max_bytes``."""
+
+        files = sorted(
+            [p for p in self.root.glob("*.json") if p.is_file()],
+            key=lambda p: p.stat().st_mtime,
+        )
+        total = sum(p.stat().st_size for p in files)
+        while total > (self.max_bytes or 0) and files:
+            victim = files.pop(0)
+            total -= victim.stat().st_size
+            try:
+                victim.unlink()
+            except FileNotFoundError:  # pragma: no cover - race safe
+                pass

--- a/micrographonia/runtime/engine.py
+++ b/micrographonia/runtime/engine.py
@@ -1,33 +1,128 @@
 from __future__ import annotations
 
+"""Async execution engine for Micrographia.
+
+This module provides :func:`run_plan` which executes a plan described by the
+:class:`~micrographonia.sdk.plan_ir.Plan` dataclass.  The implementation is a
+light-weight orchestrator supporting parallel execution, retries with
+exponential backoff, a tiny on-disk cache and the ability to resume interrupted
+runs.  The goal of the implementation is not to be feature complete but to
+provide the behaviour required by the tests in this kata.
+"""
+
+import asyncio
+import hashlib
+import json
 import time
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Callable, Dict, List
 
-from ..sdk.plan_ir import Plan
+from ..sdk.plan_ir import Node, Plan, RetryPolicy
 from ..registry.registry import Registry
 from .artifacts import RunArtifacts
-from .errors import BudgetError, EngineError, SchemaError, ToolCallError, PlanSchemaError
-from .state import State, interpolate, extract_jsonpath
+from .cache import SimpleCache, cache_key, _stable_dumps
+from .concurrency import ConcurrencyManager
+from .errors import (
+    BudgetError,
+    EngineError,
+    MicrographiaError,
+    PlanSchemaError,
+    SchemaError,
+    ToolCallError,
+)
+from .retry import RetryMatcher, backoff_delays
+from .state import State, extract_jsonpath, interpolate
 from .tools import HttpTool, InprocTool, Tool
 
 
-def run_plan(
+# ---------------------------------------------------------------------------
+def _hash_blob(data: Any) -> str:
+    return hashlib.sha256(_stable_dumps(data).encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+async def _invoke_tool(tool: Tool, payload: Dict[str, Any], timeout_ms: int | None) -> Dict:
+    timeout_s = timeout_ms / 1000.0 if timeout_ms else None
+    return await asyncio.to_thread(tool.invoke, payload, timeout_s)
+
+
+# ---------------------------------------------------------------------------
+async def run_plan_async(
     plan: Plan,
     context: Dict,
     registry: Registry,
     impls: Dict[str, Callable[[dict], dict]] | None = None,
     runs_dir: str | Path = "runs",
+    run_id: str | None = None,
+    resume: bool = True,
+    max_parallel: int | None = None,
+    cache_read: bool = True,
+    cache_write: bool = True,
 ) -> Dict:
-    """Execute *plan* sequentially."""
+    """Execute *plan* asynchronously and return a run summary."""
 
-    artifacts = RunArtifacts(runs_dir)
+    # ------------------------------------------------------------------
+    artifacts = RunArtifacts(runs_dir, run_id=run_id)
     state = State(context, plan.vars)
     state["context"]["run_output"] = str(artifacts.output_dir)
-    artifacts.write_plan(plan)
-    artifacts.write_context(state["context"])
 
-    metrics: Dict[str, Dict] = {"tool_calls": 0, "per_node": {}}
+    # Hashes used for idempotency / resume checks
+    inputs_hash = _hash_blob({"plan": asdict(plan), "context": state["context"]})
+    registry_hash = registry.content_hash()
+
+    existing = artifacts.read_run_info()
+    if existing:
+        if not resume:
+            raise EngineError("run id exists; resume disabled")
+        if existing.get("inputs_hash") != inputs_hash or existing.get("registry_hash") != registry_hash:
+            raise EngineError("cannot resume: plan/context or registry changed")
+    else:
+        artifacts.write_plan(plan)
+        artifacts.write_context(state["context"])
+        artifacts.write_run_info({"inputs_hash": inputs_hash, "registry_hash": registry_hash})
+
+    # Load previous node results when resuming
+    metrics: Dict[str, Any] = {
+        "tool_calls": 0,
+        "cache_hits": 0,
+        "per_node": {},
+        "retries": 0,
+    }
+    timeline: Dict[str, Any] = {}
+    for node in plan.graph:
+        data = artifacts.read_node_response(node.id)
+        if data:
+            response = data.get("data", {})
+            expose = {}
+            if node.out:
+                for k, path in node.out.items():
+                    expose[k] = extract_jsonpath(response, path)
+            else:
+                expose = response
+            state["nodes"][node.id] = expose
+            metrics["per_node"][node.id] = {
+                "ms": data.get("ms", 0),
+                "ok": True,
+                "cache": False,
+                "retries": 0,
+            }
+            timeline[node.id] = {"start_ms": 0, "end_ms": data.get("ms", 0)}
+
+    # ------------------------------------------------------------------
+    max_parallel = (
+        max_parallel
+        or (plan.execution.max_parallel if plan.execution and plan.execution.max_parallel else 1)
+    )
+    mgr = ConcurrencyManager(max_parallel=max_parallel)
+
+    cache_dir = Path(runs_dir) / "cache"
+    cache = SimpleCache(cache_dir)
+    cache_default = (
+        plan.execution.cache_default if plan.execution and plan.execution.cache_default is not None else False
+    )
+    retry_default = plan.execution.retry_default if plan.execution else None
+
     start = time.perf_counter()
     deadline_at = (
         start + plan.budget.deadline_ms / 1000.0
@@ -35,56 +130,52 @@ def run_plan(
         else None
     )
 
-    def _check_deadline(current_id: str) -> None:
-        if deadline_at and time.perf_counter() > deadline_at:
-            artifacts.write_node_error(current_id, "deadline exceeded")
-            raise BudgetError("deadline_ms exceeded")
+    # ------------------------------------------------------------------
+    async def run_node(node: Node) -> None:
+        nonlocal metrics
 
-    ok = True
-    last_id = None
+        if node.id in state["nodes"]:
+            return  # already completed via resume
 
-    index: Dict[str, Any] = {n.id: n for n in plan.graph}
-    seen: set[str] = set()
-    ordered: List = []
-    while len(ordered) < len(plan.graph):
-        progress = False
-        for n in plan.graph:
-            if n.id in seen:
-                continue
-            needs = n.needs or []
-            if all(req in seen or req not in index for req in needs):
-                ordered.append(n)
-                seen.add(n.id)
-                progress = True
-        if not progress:
-            raise PlanSchemaError("cycle or unsatisfied 'needs' detected")
-
-    for node in ordered:
-        last_id = node.id
-        _check_deadline(node.id)
-
-        if plan.budget and plan.budget.max_tool_calls is not None:
-            if metrics["tool_calls"] >= plan.budget.max_tool_calls:
-                artifacts.write_node_error(node.id, "budget exceeded")
-                raise BudgetError("max tool calls exceeded")
-
-        if node.needs:
-            missing = [n for n in node.needs if n not in state["nodes"]]
-            if missing:
-                artifacts.write_node_error(node.id, f"unsatisfied needs: {missing}")
-                raise PlanSchemaError(
-                    f"unsatisfied needs for node {node.id}: {missing}"
-                )
+        node_start = time.perf_counter()
+        timeline[node.id] = {"start_ms": int((node_start - start) * 1000)}
 
         try:
             inputs = interpolate(node.inputs, state)
         except SchemaError as exc:
-            ok = False
+            metrics["per_node"][node.id] = {"ms": 0, "ok": False, "retries": 0}
             artifacts.write_node_error(node.id, str(exc))
-            metrics["per_node"][node.id] = {"ms": 0, "ok": False}
-            break
+            raise
 
         manifest = registry.resolve(node.tool)
+        # Determine cache usage
+        use_cache = cache_read and (
+            (node.cache if node.cache is not None else cache_default)
+            and "side_effecting" not in (manifest.tags or [])
+        )
+
+        manifest_hash = _hash_blob(manifest.__dict__)
+        ck = cache_key(manifest.name, manifest.version, inputs, manifest_hash)
+        if use_cache:
+            cached = cache.read(ck)
+            if cached is not None:
+                metrics["cache_hits"] += 1
+                metrics["per_node"][node.id] = {
+                    "ms": 0,
+                    "ok": True,
+                    "cache": True,
+                    "retries": 0,
+                }
+                timeline[node.id]["end_ms"] = timeline[node.id]["start_ms"]
+                expose = {}
+                if node.out:
+                    for k, path in node.out.items():
+                        expose[k] = extract_jsonpath(cached, path)
+                else:
+                    expose = cached
+                state["nodes"][node.id] = expose
+                return
+
         if manifest.kind == "http":
             tool: Tool = HttpTool(manifest)
         else:
@@ -93,26 +184,62 @@ def run_plan(
             tool = InprocTool(manifest, impls[manifest.fqdn])
 
         artifacts.write_node_request(node.id, node.tool, inputs)
-        node_start = time.perf_counter()
-        try:
-            response = tool.invoke(inputs)
-        except (ToolCallError, SchemaError) as exc:
-            ok = False
-            artifacts.write_node_error(node.id, str(exc))
-            metrics["per_node"][node.id] = {
-                "ms": int((time.perf_counter() - node_start) * 1000),
-                "ok": False,
-            }
-            break
 
-        _check_deadline(node.id)
+        policy: RetryPolicy = node.retry or retry_default or RetryPolicy()
+        matcher = RetryMatcher(policy.retry_on)
+        delays = backoff_delays(policy.retries, policy.backoff_ms, policy.jitter_ms)
+        attempt = 0
+
+        while True:
+            attempt += 1
+            try:
+                # Honour deadline and per-node timeout
+                timeout_ms = node.timeout_ms
+                if deadline_at is not None:
+                    remaining = int((deadline_at - time.perf_counter()) * 1000)
+                    timeout_ms = (
+                        remaining
+                        if timeout_ms is None
+                        else min(timeout_ms, remaining)
+                    )
+                    if timeout_ms <= 0:
+                        raise BudgetError("deadline exceeded")
+
+                async with mgr.slot(manifest.fqdn, node.concurrency):
+                    response = await _invoke_tool(tool, inputs, timeout_ms)
+                if deadline_at is not None and time.perf_counter() > deadline_at:
+                    raise BudgetError("deadline exceeded")
+                break
+            except (ToolCallError, SchemaError) as exc:
+                if attempt - 1 >= policy.retries or not matcher.matches(exc):
+                    metrics["per_node"][node.id] = {
+                        "ms": int((time.perf_counter() - node_start) * 1000),
+                        "ok": False,
+                        "retries": attempt - 1,
+                    }
+                    artifacts.write_node_error(node.id, str(exc))
+                    raise
+                metrics["retries"] += 1
+                delay_ms = delays[attempt - 2]
+                if deadline_at is not None:
+                    remaining = (deadline_at - time.perf_counter()) * 1000
+                    if remaining <= 0 or delay_ms > remaining:
+                        await asyncio.sleep(max(0, remaining) / 1000)
+                        raise BudgetError("deadline exceeded")
+                await asyncio.sleep(delay_ms / 1000)
 
         node_ms = int((time.perf_counter() - node_start) * 1000)
         artifacts.write_node_response(node.id, node.tool, response, node_ms)
-        metrics["per_node"][node.id] = {"ms": node_ms, "ok": True}
+        metrics["per_node"][node.id] = {
+            "ms": node_ms,
+            "ok": True,
+            "cache": False,
+            "retries": attempt - 1,
+        }
         metrics["tool_calls"] += 1
+        timeline[node.id]["end_ms"] = int((time.perf_counter() - start) * 1000)
 
-        expose = {}
+        expose: Dict[str, Any] = {}
         if node.out:
             for key, path in node.out.items():
                 expose[key] = extract_jsonpath(response, path)
@@ -120,13 +247,112 @@ def run_plan(
             expose = response
         state["nodes"][node.id] = expose
 
+        if use_cache and cache_write:
+            cache.write(ck, response)
+
+    # ------------------------------------------------------------------
+    # Build dependency graph
+    pending: Dict[str, Node] = {n.id: n for n in plan.graph}
+    deps: Dict[str, List[str]] = {n.id: list(n.needs or []) for n in plan.graph}
+    dependents: Dict[str, List[str]] = {n.id: [] for n in plan.graph}
+    for node in plan.graph:
+        for dep in node.needs or []:
+            dependents.setdefault(dep, []).append(node.id)
+
+    # Skip nodes that already have state (resume)
+    for done_id in list(state["nodes"].keys()):
+        if done_id in deps:
+            for dep in dependents.get(done_id, []):
+                if dep in deps:
+                    deps[dep].remove(done_id)
+            deps.pop(done_id, None)
+            pending.pop(done_id, None)
+
+    ready = [pending[n_id] for n_id, d in deps.items() if not d]
+    tasks: Dict[asyncio.Task[Any], str] = {}
+    completed: set[str] = set()
+    ok = True
+    stop_exc: Exception | None = None
+
+    while ready or tasks:
+        while ready:
+            node = ready.pop()
+            task = asyncio.create_task(run_node(node))
+            tasks[task] = node.id
+
+        if not tasks:
+            break
+
+        done, _ = await asyncio.wait(tasks.keys(), return_when=asyncio.FIRST_COMPLETED)
+        for task in done:
+            node_id = tasks.pop(task)
+            try:
+                await task
+                completed.add(node_id)
+                for dep in dependents.get(node_id, []):
+                    if dep in deps:
+                        deps[dep].remove(node_id)
+                        if not deps[dep]:
+                            ready.append(pending[dep])
+            except Exception as exc:  # pragma: no cover - error path
+                ok = False
+                stop_exc = exc
+                for t in tasks:
+                    t.cancel()
+                await asyncio.gather(*tasks.keys(), return_exceptions=True)
+                ready.clear()
+                break
+
     total_ms = int((time.perf_counter() - start) * 1000)
     metrics["total_ms"] = total_ms
     artifacts.write_metrics(metrics)
-    return {
+    artifacts.write_timeline(timeline)
+
+    stop_reason = "ok"
+    if stop_exc:
+        if isinstance(stop_exc, BudgetError):
+            stop_reason = "deadline"
+        else:
+            stop_reason = "error"
+
+    summary = {
         "run_id": artifacts.run_id,
-        "ok": ok,
-        "metrics": metrics,
-        "paths": artifacts.paths,
-        "state_tail": state["nodes"].get(last_id, {}),
+        "ok": ok and not stop_exc,
+        "stop_reason": stop_reason,
+        "totals": metrics,
+        "artifacts": artifacts.paths,
     }
+    artifacts.write_summary(summary)
+    return summary
+
+
+# ---------------------------------------------------------------------------
+def run_plan(
+    plan: Plan,
+    context: Dict,
+    registry: Registry,
+    impls: Dict[str, Callable[[dict], dict]] | None = None,
+    runs_dir: str | Path = "runs",
+    run_id: str | None = None,
+    resume: bool = True,
+    max_parallel: int | None = None,
+    cache_read: bool = True,
+    cache_write: bool = True,
+) -> Dict:
+    """Synchronous wrapper around :func:`run_plan_async`."""
+
+    return asyncio.run(
+        run_plan_async(
+            plan,
+            context,
+            registry,
+            impls=impls,
+            runs_dir=runs_dir,
+            run_id=run_id,
+            resume=resume,
+            max_parallel=max_parallel,
+            cache_read=cache_read,
+            cache_write=cache_write,
+        )
+    )
+

--- a/micrographonia/sdk/cli.py
+++ b/micrographonia/sdk/cli.py
@@ -68,18 +68,37 @@ def plan_run(
     context: Path,
     registry: Path,
     runs: Path = Path("runs"),
-    deadline_ms: int | None = None,
+    run_id: str | None = typer.Option(None, help="Reuse an existing run id"),
+    resume: bool = typer.Option(True, help="Resume if run dir exists"),
+    max_parallel: int | None = typer.Option(None, help="Override plan max_parallel"),
+    cache_read: bool = typer.Option(True, help="Enable cache reads"),
+    cache_write: bool = typer.Option(True, help="Enable cache writes"),
+    emit_summary: bool = typer.Option(False, help="Emit one-line summary"),
 ) -> None:
     try:
         reg = Registry(registry)
         p = load_plan(plan)
         validate_plan(p, reg)
         ctx = json.loads(Path(context).read_text())
-        record = run_plan(p, ctx, reg, impls=_load_impls(), runs_dir=runs)
+        record = run_plan(
+            p,
+            ctx,
+            reg,
+            impls=_load_impls(),
+            runs_dir=runs,
+            run_id=run_id,
+            resume=resume,
+            max_parallel=max_parallel,
+            cache_read=cache_read,
+            cache_write=cache_write,
+        )
     except MicrographiaError as exc:
         _exit_err(exc)
         return
-    typer.echo(json.dumps(record, indent=2))
+    if emit_summary:
+        typer.echo(json.dumps(record))
+    else:
+        typer.echo(json.dumps(record, indent=2))
 
 
 @registry_app.command("health")

--- a/tests/test_engine_budget_deadline.py
+++ b/tests/test_engine_budget_deadline.py
@@ -8,7 +8,6 @@ import pytest
 from micrographonia.registry.registry import Registry
 from micrographonia.sdk.plan_ir import Plan, Node, Budget
 from micrographonia.runtime.engine import run_plan
-from micrographonia.runtime.errors import BudgetError
 
 REG_DIR = Path("registry/manifests")
 
@@ -23,5 +22,6 @@ def test_deadline_budget(tmp_path: Path) -> None:
     node = Node(id="extract", tool="extractor_A.v1", inputs={"text": "hi"})
     plan = Plan(version="0.1", graph=[node], budget=Budget(deadline_ms=50))
     impls = {"extractor_A.v1": slow_extract}
-    with pytest.raises(BudgetError):
-        run_plan(plan, {}, reg, impls=impls, runs_dir=tmp_path)
+    record = run_plan(plan, {}, reg, impls=impls, runs_dir=tmp_path)
+    assert record["ok"] is False
+    assert record["stop_reason"] == "deadline"

--- a/tests/test_engine_needs_missing.py
+++ b/tests/test_engine_needs_missing.py
@@ -26,5 +26,5 @@ def test_missing_reference(tmp_path: Path) -> None:
     plan = Plan(version="0.1", graph=[n1, n2])
     record = run_plan(plan, {}, reg, impls=IMPLS, runs_dir=tmp_path)
     assert record["ok"] is False
-    err_path = Path(record["paths"]["nodes"]["link"]["error"])
+    err_path = Path(record["artifacts"]["nodes"]["link"]["error"])
     assert err_path.exists()

--- a/tests/test_engine_smoke.py
+++ b/tests/test_engine_smoke.py
@@ -27,8 +27,9 @@ def test_engine_run(tmp_path: Path) -> None:
     ctx = json.loads(CTX_PATH.read_text())
     record = run_plan(plan, ctx, reg, impls=IMPLS, runs_dir=tmp_path)
     assert record["ok"] is True
-    assert record["metrics"]["tool_calls"] == 4
-    out_path = Path(record["state_tail"]["path"])
+    assert record["totals"]["tool_calls"] == 4
+    node_resp = Path(record["artifacts"]["nodes"]["write"]["response"])
+    out_path = Path(json.loads(node_resp.read_text())["data"]["path"])
     assert out_path.exists()
 
 
@@ -41,5 +42,5 @@ def test_engine_failure(tmp_path: Path) -> None:
     bad_impls["entity_linker.v1"] = lambda p: {}
     record = run_plan(plan, ctx, reg, impls=bad_impls, runs_dir=tmp_path)
     assert record["ok"] is False
-    node_err = record["paths"]["nodes"]["link"]["error"]
+    node_err = record["artifacts"]["nodes"]["link"]["error"]
     assert Path(node_err).exists()


### PR DESCRIPTION
## Summary
- implement async DAG engine with parallelism, retries, caching and resume support
- add JSON-on-disk cache with atomic writes and eviction
- extend CLI and validation for new orchestration features

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4e627e944832692b3af8e60b4937a