### PR TITLE
feat: add async engine with resume and cache

### DIFF
--- a/micrographonia/runtime/cache.py
+++ b/micrographonia/runtime/cache.py
@@ -25,18 +25,59 @@ def cache_key(
 
 
 class SimpleCache:
-    """Very small JSON-on-disk cache used for testing."""
+    """Very small JSON-on-disk cache used for testing.
 
-    def __init__(self, root: Path):
+    The implementation is intentionally tiny but includes a couple of
+    characteristics that are important for the runtime:
+
+    * Writes are atomic – data is written to a ``.tmp`` file and then
+      atomically renamed over the target path to avoid torn writes.
+    * A size cap (``max_bytes``) can be supplied; when the cache grows
+      beyond the limit the oldest entries are evicted in a basic LRU
+      manner.
+
+    The cache stores each entry as ``<key>.json`` containing a JSON
+    document.  Keys are assumed to already be content addressed.
+    """
+
+    def __init__(self, root: Path, max_bytes: int | None = None):
         self.root = root
+        self.max_bytes = max_bytes
         self.root.mkdir(parents=True, exist_ok=True)
 
+    # ------------------------------------------------------------------
+    def _path(self, key: str) -> Path:
+        return self.root / f"{key}.json"
+
+    # ------------------------------------------------------------------
     def read(self, key: str) -> Any | None:
-        path = self.root / f"{key}.json"
+        path = self._path(key)
         if not path.exists():
             return None
         return json.loads(path.read_text())
 
+    # ------------------------------------------------------------------
     def write(self, key: str, data: Any) -> None:
-        path = self.root / f"{key}.json"
-        path.write_text(_stable_dumps(data))
+        path = self._path(key)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(_stable_dumps(data))
+        tmp.replace(path)
+        if self.max_bytes is not None:
+            self._enforce_size()
+
+    # ------------------------------------------------------------------
+    def _enforce_size(self) -> None:
+        """Delete oldest files until the cache fits ``max_bytes``."""
+
+        files = sorted(
+            [p for p in self.root.glob("*.json") if p.is_file()],
+            key=lambda p: p.stat().st_mtime,
+        )
+        total = sum(p.stat().st_size for p in files)
+        while total > (self.max_bytes or 0) and files:
+            victim = files.pop(0)
+            total -= victim.stat().st_size
+            try:
+                victim.unlink()
+            except FileNotFoundError:  # pragma: no cover - race safe
+                pass

--- a/micrographonia/runtime/engine.py
+++ b/micrographonia/runtime/engine.py
@@ -1,33 +1,145 @@
 from __future__ import annotations
 
-import time
-from pathlib import Path
-from typing import Any, Callable, Dict, List
+"""Async execution engine for Micrographia.
 
-from ..sdk.plan_ir import Plan
+This module provides :func:`run_plan` which executes a plan described by the
+:class:`~micrographonia.sdk.plan_ir.Plan` dataclass.  The implementation is a
+light-weight orchestrator supporting parallel execution, retries with
+exponential backoff, a tiny on-disk cache and the ability to resume interrupted
+runs.  The goal of the implementation is not to be feature complete but to
+provide the behaviour required by the tests in this kata.
+"""
+
+import asyncio
+import hashlib
+import json
+import time
+import datetime as _dt
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Tuple
+
+from ..sdk.plan_ir import Node, Plan, RetryPolicy
 from ..registry.registry import Registry
 from .artifacts import RunArtifacts
-from .errors import BudgetError, EngineError, SchemaError, ToolCallError, PlanSchemaError
-from .state import State, interpolate, extract_jsonpath
+from .cache import SimpleCache, cache_key, _stable_dumps
+from .concurrency import ConcurrencyManager
+from .errors import (
+    BudgetError,
+    EngineError,
+    MicrographiaError,
+    PlanSchemaError,
+    SchemaError,
+    ToolCallError,
+)
+from .retry import RetryMatcher, backoff_delays
+from .state import State, extract_jsonpath, interpolate
 from .tools import HttpTool, InprocTool, Tool
 
 
-def run_plan(
+# ---------------------------------------------------------------------------
+def _hash_blob(data: Any) -> str:
+    return hashlib.sha256(_stable_dumps(data).encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+async def _invoke_tool(tool: Tool, payload: Dict[str, Any], timeout_ms: int | None) -> Dict:
+    timeout_s = timeout_ms / 1000.0 if timeout_ms else None
+    return await asyncio.to_thread(tool.invoke, payload, timeout_s)
+
+
+# ---------------------------------------------------------------------------
+async def run_plan_async(
     plan: Plan,
     context: Dict,
     registry: Registry,
     impls: Dict[str, Callable[[dict], dict]] | None = None,
     runs_dir: str | Path = "runs",
-) -> Dict:
-    """Execute *plan* sequentially."""
+    run_id: str | None = None,
+    resume: bool = True,
+    max_parallel: int | None = None,
+    cache_read: bool = True,
+    cache_write: bool = True,
+) -> Tuple[Dict, MicrographiaError | None]:
+    """Execute *plan* asynchronously.
 
-    artifacts = RunArtifacts(runs_dir)
+    Returns a tuple ``(summary, error)`` where ``summary`` contains basic
+    run information and ``error`` is ``None`` on success or the terminal
+    :class:`MicrographiaError` if the run failed.  The summary and metrics are
+    written to disk regardless of success or failure.
+    """
+
+    # ------------------------------------------------------------------
+    artifacts = RunArtifacts(runs_dir, run_id=run_id)
     state = State(context, plan.vars)
     state["context"]["run_output"] = str(artifacts.output_dir)
-    artifacts.write_plan(plan)
-    artifacts.write_context(state["context"])
 
-    metrics: Dict[str, Dict] = {"tool_calls": 0, "per_node": {}}
+    # Hashes used for idempotency / resume checks
+    inputs_hash = _hash_blob({"plan": asdict(plan), "context": state["context"]})
+    registry_hash = registry.content_hash()
+
+    existing = artifacts.read_run_info()
+    if existing:
+        if not resume:
+            raise EngineError("run id exists; resume disabled")
+        if existing.get("inputs_hash") != inputs_hash or existing.get("registry_hash") != registry_hash:
+            raise EngineError("cannot resume: plan/context or registry changed")
+    else:
+        artifacts.write_plan(plan)
+        artifacts.write_context(state["context"])
+        artifacts.write_run_info(
+            {
+                "inputs_hash": inputs_hash,
+                "registry_hash": registry_hash,
+                "created_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+            }
+        )
+
+    # Load previous node results when resuming
+    metrics: Dict[str, Any] = {
+        "tool_calls": 0,
+        "cache_hits": 0,
+        "per_node": {},
+        "retries": 0,
+    }
+    timeline: Dict[str, Any] = {}
+    for node in plan.graph:
+        data = artifacts.read_node_response(node.id)
+        if data:
+            response = data.get("data", {})
+            expose = {}
+            if node.out:
+                for k, path in node.out.items():
+                    expose[k] = extract_jsonpath(response, path)
+            else:
+                expose = response
+            state["nodes"][node.id] = expose
+            manifest = registry.resolve(node.tool)
+            cache_val: Any = (
+                "bypassed:side_effect" if "side_effecting" in (manifest.tags or []) else False
+            )
+            metrics["per_node"][node.id] = {
+                "ms": data.get("ms", 0),
+                "ok": True,
+                "cache": cache_val,
+                "retries": 0,
+            }
+            timeline[node.id] = {"start_ms": 0, "end_ms": data.get("ms", 0)}
+
+    # ------------------------------------------------------------------
+    max_parallel = (
+        max_parallel
+        or (plan.execution.max_parallel if plan.execution and plan.execution.max_parallel else 1)
+    )
+    mgr = ConcurrencyManager(max_parallel=max_parallel)
+
+    cache_dir = Path(runs_dir) / "cache"
+    cache = SimpleCache(cache_dir)
+    cache_default = (
+        plan.execution.cache_default if plan.execution and plan.execution.cache_default is not None else False
+    )
+    retry_default = plan.execution.retry_default if plan.execution else None
+
     start = time.perf_counter()
     deadline_at = (
         start + plan.budget.deadline_ms / 1000.0
@@ -35,56 +147,53 @@ def run_plan(
         else None
     )
 
-    def _check_deadline(current_id: str) -> None:
-        if deadline_at and time.perf_counter() > deadline_at:
-            artifacts.write_node_error(current_id, "deadline exceeded")
-            raise BudgetError("deadline_ms exceeded")
+    # ------------------------------------------------------------------
+    async def run_node(node: Node) -> None:
+        nonlocal metrics
 
-    ok = True
-    last_id = None
+        if node.id in state["nodes"]:
+            return  # already completed via resume
 
-    index: Dict[str, Any] = {n.id: n for n in plan.graph}
-    seen: set[str] = set()
-    ordered: List = []
-    while len(ordered) < len(plan.graph):
-        progress = False
-        for n in plan.graph:
-            if n.id in seen:
-                continue
-            needs = n.needs or []
-            if all(req in seen or req not in index for req in needs):
-                ordered.append(n)
-                seen.add(n.id)
-                progress = True
-        if not progress:
-            raise PlanSchemaError("cycle or unsatisfied 'needs' detected")
-
-    for node in ordered:
-        last_id = node.id
-        _check_deadline(node.id)
-
-        if plan.budget and plan.budget.max_tool_calls is not None:
-            if metrics["tool_calls"] >= plan.budget.max_tool_calls:
-                artifacts.write_node_error(node.id, "budget exceeded")
-                raise BudgetError("max tool calls exceeded")
-
-        if node.needs:
-            missing = [n for n in node.needs if n not in state["nodes"]]
-            if missing:
-                artifacts.write_node_error(node.id, f"unsatisfied needs: {missing}")
-                raise PlanSchemaError(
-                    f"unsatisfied needs for node {node.id}: {missing}"
-                )
+        node_start = time.perf_counter()
+        start_ms = int((node_start - start) * 1000)
+        timeline[node.id] = {"start_ms": start_ms, "attempts": [start_ms]}
 
         try:
             inputs = interpolate(node.inputs, state)
         except SchemaError as exc:
-            ok = False
+            metrics["per_node"][node.id] = {"ms": 0, "ok": False, "retries": 0}
             artifacts.write_node_error(node.id, str(exc))
-            metrics["per_node"][node.id] = {"ms": 0, "ok": False}
-            break
+            raise
 
         manifest = registry.resolve(node.tool)
+        side_effect = "side_effecting" in (manifest.tags or [])
+        use_cache = cache_read and (
+            (node.cache if node.cache is not None else cache_default) and not side_effect
+        )
+        cache_status: Any = "bypassed:side_effect" if side_effect else False
+
+        manifest_hash = _hash_blob(manifest.__dict__)
+        ck = cache_key(manifest.name, manifest.version, inputs, manifest_hash)
+        if use_cache:
+            cached = cache.read(ck)
+            if cached is not None:
+                metrics["cache_hits"] += 1
+                metrics["per_node"][node.id] = {
+                    "ms": 0,
+                    "ok": True,
+                    "cache": True,
+                    "retries": 0,
+                }
+                timeline[node.id]["end_ms"] = timeline[node.id]["start_ms"]
+                expose = {}
+                if node.out:
+                    for k, path in node.out.items():
+                        expose[k] = extract_jsonpath(cached, path)
+                else:
+                    expose = cached
+                state["nodes"][node.id] = expose
+                return
+
         if manifest.kind == "http":
             tool: Tool = HttpTool(manifest)
         else:
@@ -93,26 +202,69 @@ def run_plan(
             tool = InprocTool(manifest, impls[manifest.fqdn])
 
         artifacts.write_node_request(node.id, node.tool, inputs)
-        node_start = time.perf_counter()
-        try:
-            response = tool.invoke(inputs)
-        except (ToolCallError, SchemaError) as exc:
-            ok = False
-            artifacts.write_node_error(node.id, str(exc))
-            metrics["per_node"][node.id] = {
-                "ms": int((time.perf_counter() - node_start) * 1000),
-                "ok": False,
-            }
-            break
 
-        _check_deadline(node.id)
+        policy: RetryPolicy = node.retry or retry_default or RetryPolicy()
+        matcher = RetryMatcher(policy.retry_on)
+        delays = backoff_delays(policy.retries, policy.backoff_ms, policy.jitter_ms)
+        attempt = 0
+
+        while True:
+            attempt += 1
+            if attempt > 1:
+                timeline[node.id]["attempts"].append(
+                    int((time.perf_counter() - start) * 1000)
+                )
+            try:
+                # Honour deadline and per-node timeout
+                timeout_ms = node.timeout_ms
+                if deadline_at is not None:
+                    remaining = int((deadline_at - time.perf_counter()) * 1000)
+                    timeout_ms = (
+                        remaining
+                        if timeout_ms is None
+                        else min(timeout_ms, remaining)
+                    )
+                    if timeout_ms <= 0:
+                        raise BudgetError("deadline exceeded")
+
+                async with mgr.slot(manifest.fqdn, node.concurrency):
+                    response = await _invoke_tool(tool, inputs, timeout_ms)
+                if deadline_at is not None and time.perf_counter() > deadline_at:
+                    raise BudgetError("deadline exceeded")
+                break
+            except (ToolCallError, SchemaError) as exc:
+                if attempt - 1 >= policy.retries or not matcher.matches(exc):
+                    node_ms = int((time.perf_counter() - node_start) * 1000)
+                    timeline[node.id]["end_ms"] = int((time.perf_counter() - start) * 1000)
+                    metrics["per_node"][node.id] = {
+                        "ms": node_ms,
+                        "ok": False,
+                        "cache": cache_status,
+                        "retries": attempt - 1,
+                    }
+                    artifacts.write_node_error(node.id, str(exc))
+                    raise
+                metrics["retries"] += 1
+                delay_ms = delays[attempt - 2]
+                if deadline_at is not None:
+                    remaining = (deadline_at - time.perf_counter()) * 1000
+                    if remaining <= 0 or delay_ms > remaining:
+                        await asyncio.sleep(max(0, remaining) / 1000)
+                        raise BudgetError("deadline exceeded")
+                await asyncio.sleep(delay_ms / 1000)
 
         node_ms = int((time.perf_counter() - node_start) * 1000)
         artifacts.write_node_response(node.id, node.tool, response, node_ms)
-        metrics["per_node"][node.id] = {"ms": node_ms, "ok": True}
+        metrics["per_node"][node.id] = {
+            "ms": node_ms,
+            "ok": True,
+            "cache": cache_status,
+            "retries": attempt - 1,
+        }
         metrics["tool_calls"] += 1
+        timeline[node.id]["end_ms"] = int((time.perf_counter() - start) * 1000)
 
-        expose = {}
+        expose: Dict[str, Any] = {}
         if node.out:
             for key, path in node.out.items():
                 expose[key] = extract_jsonpath(response, path)
@@ -120,13 +272,121 @@ def run_plan(
             expose = response
         state["nodes"][node.id] = expose
 
+        if use_cache and cache_write:
+            cache.write(ck, response)
+
+    # ------------------------------------------------------------------
+    # Build dependency graph
+    pending: Dict[str, Node] = {n.id: n for n in plan.graph}
+    deps: Dict[str, List[str]] = {n.id: list(n.needs or []) for n in plan.graph}
+    dependents: Dict[str, List[str]] = {n.id: [] for n in plan.graph}
+    for node in plan.graph:
+        for dep in node.needs or []:
+            dependents.setdefault(dep, []).append(node.id)
+
+    # Skip nodes that already have state (resume)
+    for done_id in list(state["nodes"].keys()):
+        if done_id in deps:
+            for dep in dependents.get(done_id, []):
+                if dep in deps:
+                    deps[dep].remove(done_id)
+            deps.pop(done_id, None)
+            pending.pop(done_id, None)
+
+    ready = [pending[n_id] for n_id, d in deps.items() if not d]
+    tasks: Dict[asyncio.Task[Any], str] = {}
+    completed: set[str] = set()
+    ok = True
+    stop_exc: Exception | None = None
+
+    while ready or tasks:
+        while ready:
+            node = ready.pop()
+            task = asyncio.create_task(run_node(node))
+            tasks[task] = node.id
+
+        if not tasks:
+            break
+
+        done, _ = await asyncio.wait(tasks.keys(), return_when=asyncio.FIRST_COMPLETED)
+        for task in done:
+            node_id = tasks.pop(task)
+            try:
+                await task
+                completed.add(node_id)
+                for dep in dependents.get(node_id, []):
+                    if dep in deps:
+                        deps[dep].remove(node_id)
+                        if not deps[dep]:
+                            ready.append(pending[dep])
+            except Exception as exc:  # pragma: no cover - error path
+                ok = False
+                stop_exc = exc
+                for t in tasks:
+                    t.cancel()
+                await asyncio.gather(*tasks.keys(), return_exceptions=True)
+                ready.clear()
+                break
+
     total_ms = int((time.perf_counter() - start) * 1000)
     metrics["total_ms"] = total_ms
+
+    stop_reason = None
+    if stop_exc:
+        if isinstance(stop_exc, BudgetError):
+            stop_reason = "deadline"
+        else:
+            stop_reason = f"error:{type(stop_exc).__name__}"
+    metrics["stop_reason"] = stop_reason
+
     artifacts.write_metrics(metrics)
-    return {
+    artifacts.write_timeline(timeline)
+
+    summary = {
         "run_id": artifacts.run_id,
-        "ok": ok,
-        "metrics": metrics,
-        "paths": artifacts.paths,
-        "state_tail": state["nodes"].get(last_id, {}),
+        "ok": ok and not stop_exc,
+        "stop_reason": stop_reason,
+        "totals": {
+            "nodes": len(plan.graph),
+            "tool_calls": metrics["tool_calls"],
+            "cache_hits": metrics["cache_hits"],
+            "retries": metrics["retries"],
+            "total_ms": metrics["total_ms"],
+        },
+        "artifacts": artifacts.paths,
     }
+    artifacts.write_summary(summary)
+    return summary, stop_exc
+
+
+# ---------------------------------------------------------------------------
+def run_plan(
+    plan: Plan,
+    context: Dict,
+    registry: Registry,
+    impls: Dict[str, Callable[[dict], dict]] | None = None,
+    runs_dir: str | Path = "runs",
+    run_id: str | None = None,
+    resume: bool = True,
+    max_parallel: int | None = None,
+    cache_read: bool = True,
+    cache_write: bool = True,
+
+) -> Tuple[Dict, MicrographiaError | None]:
+    """Synchronous wrapper around :func:`run_plan_async`."""
+
+    return asyncio.run(
+        run_plan_async(
+            plan,
+            context,
+            registry,
+            impls=impls,
+            runs_dir=runs_dir,
+            run_id=run_id,
+            resume=resume,
+            max_parallel=max_parallel,
+            cache_read=cache_read,
+            cache_write=cache_write,
+        )
+    )
+

--- a/registry/manifests/kg_writer.v1.json
+++ b/registry/manifests/kg_writer.v1.json
@@ -2,6 +2,7 @@
   "name": "kg_writer",
   "version": "v1",
   "kind": "inproc",
+  "tags": ["side_effecting"],
   "input_schema": {
     "type": "object",
     "required": ["triples", "path"],

--- a/tests/test_artifacts_resume.py
+++ b/tests/test_artifacts_resume.py
@@ -1,0 +1,8 @@
+from micrographonia.runtime.artifacts import RunArtifacts
+
+def test_read_run_info(tmp_path):
+    ra = RunArtifacts(tmp_path, run_id="abcd1234")
+    info = {"inputs_hash": "i", "registry_hash": "r", "created_at": "now"}
+    ra.write_run_info(info)
+    ra2 = RunArtifacts(tmp_path, run_id="abcd1234")
+    assert ra2.read_run_info() == info

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,5 @@
-from micrographonia.runtime.cache import cache_key
+import time
+from micrographonia.runtime.cache import cache_key, SimpleCache
 
 
 def test_cache_key_stability() -> None:
@@ -9,3 +10,15 @@ def test_cache_key_stability() -> None:
     assert key1 == key2
     assert key1 != key3
     assert key1 != key4
+
+
+def test_cache_eviction(tmp_path) -> None:
+    cache = SimpleCache(tmp_path, max_bytes=20)
+    cache.write("a", {"v": "a"})
+    time.sleep(0.01)
+    cache.write("b", {"v": "b"})
+    time.sleep(0.01)
+    cache.write("c", {"v": "c"})
+    files = {p.name for p in tmp_path.glob("*.json")}
+    assert "a.json" not in files  # oldest evicted
+    assert "b.json" in files and "c.json" in files

--- a/tests/test_cli_summary.py
+++ b/tests/test_cli_summary.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from micrographonia.sdk.cli import app
+
+REG_DIR = Path("registry/manifests").resolve()
+
+
+def _write(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data))
+
+
+def test_cli_emit_summary(tmp_path: Path) -> None:
+    plan_path = tmp_path / "plan.json"
+    ctx_path = tmp_path / "ctx.json"
+    _write(plan_path, {"version": "0.1", "graph": [{"id": "extract", "tool": "extractor_A.v1", "inputs": {"text": "hi"}}]})
+    _write(ctx_path, {})
+    runner = CliRunner()
+    env = {"PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    result = runner.invoke(
+        app,
+        [
+            "plan",
+            "run",
+            str(plan_path),
+            str(ctx_path),
+            str(REG_DIR),
+            "--runs",
+            str(tmp_path / "runs"),
+            "--emit-summary",
+        ],
+        env=env,
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.stdout.strip())
+    assert data["ok"] is True
+    assert data["stop_reason"] is None
+
+
+def test_cli_exit_code_deadline(tmp_path: Path) -> None:
+    plan_path = tmp_path / "plan.json"
+    ctx_path = tmp_path / "ctx.json"
+    _write(plan_path, {
+        "version": "0.1",
+        "budget": {"deadline_ms": 1},
+        "graph": [{"id": "extract", "tool": "extractor_A.v1", "inputs": {"text": "hi"}}],
+    })
+    _write(ctx_path, {})
+    runner = CliRunner()
+    env = {"PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    result = runner.invoke(
+        app,
+        [
+            "plan",
+            "run",
+            str(plan_path),
+            str(ctx_path),
+            str(REG_DIR),
+            "--runs",
+            str(tmp_path / "runs"),
+            "--emit-summary",
+        ],
+        env=env,
+    )
+    assert result.exit_code == 14
+    data = json.loads(result.stdout.strip())
+    assert data["stop_reason"] == "deadline"

--- a/tests/test_engine_budget_deadline.py
+++ b/tests/test_engine_budget_deadline.py
@@ -23,5 +23,7 @@ def test_deadline_budget(tmp_path: Path) -> None:
     node = Node(id="extract", tool="extractor_A.v1", inputs={"text": "hi"})
     plan = Plan(version="0.1", graph=[node], budget=Budget(deadline_ms=50))
     impls = {"extractor_A.v1": slow_extract}
-    with pytest.raises(BudgetError):
-        run_plan(plan, {}, reg, impls=impls, runs_dir=tmp_path)
+    record, err = run_plan(plan, {}, reg, impls=impls, runs_dir=tmp_path)
+    assert record["ok"] is False
+    assert record["stop_reason"] == "deadline"
+    assert isinstance(err, BudgetError)

--- a/tests/test_engine_needs_missing.py
+++ b/tests/test_engine_needs_missing.py
@@ -24,7 +24,8 @@ def test_missing_reference(tmp_path: Path) -> None:
         inputs={"mentions": "${extract.missing}"},
     )
     plan = Plan(version="0.1", graph=[n1, n2])
-    record = run_plan(plan, {}, reg, impls=IMPLS, runs_dir=tmp_path)
+    record, err = run_plan(plan, {}, reg, impls=IMPLS, runs_dir=tmp_path)
     assert record["ok"] is False
-    err_path = Path(record["paths"]["nodes"]["link"]["error"])
+    assert err is not None
+    err_path = Path(record["artifacts"]["nodes"]["link"]["error"])
     assert err_path.exists()

--- a/tests/test_engine_resume.py
+++ b/tests/test_engine_resume.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+import pytest
+
+from micrographonia.registry.registry import Registry
+from micrographonia.sdk.plan_ir import Plan, Node, Execution
+from micrographonia.runtime.engine import run_plan
+from micrographonia.runtime.errors import EngineError, ToolCallError
+from micrographonia.tools.stubs import extractor_A, entity_linker, kg_writer
+
+REG_DIR = Path("registry/manifests")
+
+
+def test_resume_happy(tmp_path: Path) -> None:
+    reg = Registry(REG_DIR)
+    plan = Plan(
+        version="0.1",
+        graph=[
+            Node(id="extract", tool="extractor_A.v1", inputs={"text": "hi"}),
+            Node(
+                id="link",
+                tool="entity_linker.v1",
+                needs=["extract"],
+                inputs={"mentions": "${extract.mentions}"},
+            ),
+            Node(
+                id="write",
+                tool="kg_writer.v1",
+                needs=["link"],
+                inputs={"triples": [], "path": "${context.run_output}/out.json"},
+            ),
+        ],
+        execution=Execution(cache_default=True),
+    )
+    counts = {"extract": 0, "link": 0, "write": 0}
+
+    def extract(p):
+        counts["extract"] += 1
+        return extractor_A(p)
+
+    fail = {"flag": True}
+
+    def link_fail(p):
+        counts["link"] += 1
+        if fail["flag"]:
+            fail["flag"] = False
+            raise ToolCallError("boom", code=500)
+        return entity_linker(p)
+
+    def link_ok(p):
+        counts["link"] += 1
+        return entity_linker(p)
+
+    def write(p):
+        counts["write"] += 1
+        return kg_writer(p)
+
+    impls1 = {
+        "extractor_A.v1": extract,
+        "entity_linker.v1": link_fail,
+        "kg_writer.v1": write,
+    }
+    record1, err1 = run_plan(plan, {}, reg, impls=impls1, runs_dir=tmp_path, run_id="r1")
+    assert err1 is not None
+
+    impls2 = {
+        "extractor_A.v1": extract,
+        "entity_linker.v1": link_ok,
+        "kg_writer.v1": write,
+    }
+    record2, err2 = run_plan(plan, {}, reg, impls=impls2, runs_dir=tmp_path, run_id="r1")
+    assert err2 is None
+    assert record2["ok"] is True
+    assert counts["extract"] == 1
+    assert record2["totals"]["tool_calls"] == 2
+
+
+def test_resume_mismatch(tmp_path: Path) -> None:
+    reg = Registry(REG_DIR)
+    n1 = Node(id="extract", tool="extractor_A.v1", inputs={"text": "hi"})
+    plan1 = Plan(version="0.1", graph=[n1])
+    impls = {"extractor_A.v1": extractor_A}
+    run_plan(plan1, {}, reg, impls=impls, runs_dir=tmp_path, run_id="r2")
+
+    n2 = Node(id="extra", tool="extractor_A.v1", inputs={"text": "hi"})
+    plan2 = Plan(version="0.1", graph=[n1, n2])
+    with pytest.raises(EngineError):
+        run_plan(plan2, {}, reg, impls=impls, runs_dir=tmp_path, run_id="r2")

--- a/tests/test_engine_side_effect.py
+++ b/tests/test_engine_side_effect.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from micrographonia.registry.registry import Registry
+from micrographonia.sdk.plan_ir import Plan, Node, Execution
+from micrographonia.runtime.engine import run_plan
+from micrographonia.tools.stubs import extractor_A, kg_writer
+
+REG_DIR = Path("registry/manifests")
+
+
+def test_side_effect_bypass(tmp_path: Path) -> None:
+    reg = Registry(REG_DIR)
+    plan = Plan(
+        version="0.1",
+        execution=Execution(cache_default=True),
+        graph=[
+            Node(id="extract", tool="extractor_A.v1", inputs={"text": "hi"}),
+            Node(
+                id="write",
+                tool="kg_writer.v1",
+                needs=["extract"],
+                inputs={"triples": [], "path": "${context.run_output}/out.json"},
+            ),
+        ],
+    )
+    calls = {"write": 0}
+
+    def writer(p):
+        calls["write"] += 1
+        return kg_writer.run(p)
+
+    impls = {"extractor_A.v1": extractor_A, "kg_writer.v1": writer}
+    run_plan(plan, {}, reg, impls=impls, runs_dir=tmp_path)
+    record2, _ = run_plan(plan, {}, reg, impls=impls, runs_dir=tmp_path)
+    assert calls["write"] == 2
+    assert record2["totals"]["cache_hits"] == 1

--- a/tests/test_engine_smoke.py
+++ b/tests/test_engine_smoke.py
@@ -25,10 +25,12 @@ def test_engine_run(tmp_path: Path) -> None:
     plan = load_plan(PLAN_PATH)
     validate_plan(plan, reg)
     ctx = json.loads(CTX_PATH.read_text())
-    record = run_plan(plan, ctx, reg, impls=IMPLS, runs_dir=tmp_path)
+    record, err = run_plan(plan, ctx, reg, impls=IMPLS, runs_dir=tmp_path)
+    assert err is None
     assert record["ok"] is True
-    assert record["metrics"]["tool_calls"] == 4
-    out_path = Path(record["state_tail"]["path"])
+    assert record["totals"]["tool_calls"] == 4
+    node_resp = Path(record["artifacts"]["nodes"]["write"]["response"])
+    out_path = Path(json.loads(node_resp.read_text())["data"]["path"])
     assert out_path.exists()
 
 
@@ -39,7 +41,8 @@ def test_engine_failure(tmp_path: Path) -> None:
     ctx = json.loads(CTX_PATH.read_text())
     bad_impls = dict(IMPLS)
     bad_impls["entity_linker.v1"] = lambda p: {}
-    record = run_plan(plan, ctx, reg, impls=bad_impls, runs_dir=tmp_path)
+    record, err = run_plan(plan, ctx, reg, impls=bad_impls, runs_dir=tmp_path)
     assert record["ok"] is False
-    node_err = record["paths"]["nodes"]["link"]["error"]
+    assert err is not None
+    node_err = record["artifacts"]["nodes"]["link"]["error"]
     assert Path(node_err).exists()


### PR DESCRIPTION
## Summary
- implement async DAG engine with parallelism, retries, caching and resume support
- add JSON-on-disk cache with atomic writes and eviction
- extend CLI and validation for new orchestration features

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e627e944832692b3af8e60b4937a