### PR TITLE
Document components and add missing docstrings

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,26 @@
+# Examples
+
+Sample datasets, plans, and scripts demonstrating how to use **Micrographia**.
+
+## Why examples?
+These snippets act as executable documentation and inspiration for building domain pipelines. Each example shows how tiny specialists combine to produce structured artifacts.
+
+## Quick start
+Run the smallest end-to-end example:
+
+```bash
+python run_hello.py
+# ✅ Wrote 2 triples to examples/kg.json
+```
+
+## Running a plan
+Use the CLI to execute a plan and context from the repository root:
+
+```bash
+python -m micrographonia.sdk.cli plan.run \
+  --plan examples/manual_plans/notes.yml \
+  --context examples/datasets/note.json \
+  --registry registry/manifests
+```
+
+Modify the YAML plan or dataset to adapt this flow to your own domain.

--- a/micrographonia/README.md
+++ b/micrographonia/README.md
@@ -1,0 +1,24 @@
+# Micrographonia Package
+
+Core library code for **Micrographia**. It provides the building blocks that coordinate small model specialists.
+
+## Modules
+- `runtime/` – asynchronous engine that schedules tool calls with retries and caching.
+- `registry/` – manifest loader that resolves tool contracts.
+- `sdk/` – user-facing helpers and CLI entry points.
+- `tools/` – stub implementations and interfaces for external services.
+
+## Example
+Load a plan and execute it with the runtime:
+
+```python
+from micrographonia.registry import Registry
+from micrographonia.runtime.engine import run_plan
+from micrographonia.sdk.plan_ir import load_plan
+
+plan = load_plan("examples/manual_plans/notes.yml")
+registry = Registry("registry/manifests")
+summary, err = run_plan(plan, {"namespace": "demo"}, registry)
+```
+
+This package is intended as a reference implementation; swap the stubs for real services or fine‑tuned models as your pipeline grows.

--- a/micrographonia/registry/README.md
+++ b/micrographonia/registry/README.md
@@ -1,0 +1,22 @@
+# Registry
+
+Utilities for loading tool manifests from disk and resolving them during plan execution. The registry keeps tool definitions decoupled from code so pipelines can swap implementations easily.
+
+## Manifest format
+A manifest is a JSON document describing a tool endpoint and its schema:
+
+```json
+{
+  "id": "extractor_A.v1",
+  "url": "http://localhost:8000/extract",
+  "inputs": { "text": "string" },
+  "outputs": { "triples": "list" }
+}
+```
+
+## Usage
+```python
+from micrographonia.registry import Registry
+registry = Registry("registry/manifests")
+extract_manifest = registry.resolve("extractor_A.v1")
+```

--- a/micrographonia/registry/manifest.py
+++ b/micrographonia/registry/manifest.py
@@ -1,3 +1,5 @@
+"""Dataclasses describing tools available in the registry."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/micrographonia/registry/registry.py
+++ b/micrographonia/registry/registry.py
@@ -1,3 +1,5 @@
+"""Filesystem-backed registry for resolving tool manifests."""
+
 from __future__ import annotations
 
 import json

--- a/micrographonia/runtime/README.md
+++ b/micrographonia/runtime/README.md
@@ -1,0 +1,16 @@
+# Runtime
+
+Asynchronous execution engine orchestrating tool calls, caching, retries and state management for running Micrographia plans. Inspired by workflow schedulers and DAG executors, it focuses on reliability and transparency.
+
+## Usage
+```python
+from micrographonia.runtime.engine import run_plan
+from micrographonia.registry import Registry
+from micrographonia.sdk.plan_ir import load_plan
+
+plan = load_plan("examples/manual_plans/notes.yml")
+registry = Registry("registry/manifests")
+summary, err = run_plan(plan, {"namespace": "demo"}, registry)
+```
+
+The runtime handles parallelism, backoff and resumable runs so experiments can start simple and grow into complex pipelines.

--- a/micrographonia/runtime/retry.py
+++ b/micrographonia/runtime/retry.py
@@ -1,3 +1,5 @@
+"""Utilities for parsing retry policies and computing backoff delays."""
+
 from __future__ import annotations
 
 import random
@@ -9,6 +11,8 @@ from .errors import EngineError, SchemaError, ToolCallError
 
 @dataclass
 class _Rule:
+    """Internal representation of a single retry rule."""
+
     exc_type: type
     code: int | None = None
     family: int | None = None
@@ -28,6 +32,8 @@ class RetryMatcher:
         self.rules: List[_Rule] = [self._parse(p) for p in patterns]
 
     def _parse(self, pattern: str) -> _Rule:
+        """Convert a retry *pattern* string into a :class:`_Rule`."""
+
         cls_name, _, spec = pattern.partition(":")
         exc_type = self._MAP.get(cls_name)
         if exc_type is None:

--- a/micrographonia/runtime/state.py
+++ b/micrographonia/runtime/state.py
@@ -1,3 +1,5 @@
+"""Helpers for managing runtime state and resolving references."""
+
 from __future__ import annotations
 
 import re
@@ -19,6 +21,8 @@ class State(Dict[str, Any]):
 
 
 def _resolve_expr(expr: str, state: State) -> Any:
+    """Resolve a dotted ``expr`` against the current ``state``."""
+
     parts = expr.split(".")
     if parts[0] == "context":
         target = state["context"]

--- a/micrographonia/sdk/README.md
+++ b/micrographonia/sdk/README.md
@@ -1,0 +1,23 @@
+# SDK
+
+User-facing helpers and the command line interface for loading, validating and executing Micrographia plans. The SDK is the main entry point for developing and testing pipelines.
+
+## CLI examples
+Validate a plan:
+
+```bash
+python -m micrographonia.sdk.cli plan.validate \
+  --plan examples/manual_plans/notes.yml \
+  --registry registry/manifests
+```
+
+Execute a plan:
+
+```bash
+python -m micrographonia.sdk.cli plan.run \
+  --plan examples/manual_plans/notes.yml \
+  --context examples/datasets/note.json \
+  --registry registry/manifests
+```
+
+The SDK also exposes Python helpers for loading plans, validating schemas and invoking the runtime programmatically.

--- a/micrographonia/sdk/cli.py
+++ b/micrographonia/sdk/cli.py
@@ -1,3 +1,5 @@
+"""Command line interface for validating and executing plans."""
+
 from __future__ import annotations
 
 import json

--- a/micrographonia/sdk/plan_ir.py
+++ b/micrographonia/sdk/plan_ir.py
@@ -1,3 +1,5 @@
+"""Dataclasses representing the plan intermediate representation."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/micrographonia/sdk/validate.py
+++ b/micrographonia/sdk/validate.py
@@ -1,3 +1,5 @@
+"""Helpers for loading plans and validating their structure."""
+
 from __future__ import annotations
 
 import json
@@ -30,6 +32,8 @@ def load_plan(path: str | Path) -> Plan:
 
 
 def _from_dict(data: Dict) -> Plan:
+    """Construct a :class:`Plan` from a plain dictionary."""
+
     budget = data.get("budget")
     budget_obj = Budget(**budget) if budget else None
 
@@ -101,6 +105,8 @@ def validate_plan(plan: Plan, registry: Registry) -> None:
 
 
 def _check_acyclic(edges: Dict[str, List[str]]) -> None:
+    """Ensure that the dependency graph described by ``edges`` is acyclic."""
+
     temp: Set[str] = set()
     perm: Set[str] = set()
 

--- a/micrographonia/tools/README.md
+++ b/micrographonia/tools/README.md
@@ -1,0 +1,18 @@
+# Tools
+
+Reference implementations and stub tools used by the runtime and tests. Real deployments would swap these stubs for calls to specialised models or services.
+
+## Included stubs
+- `extractor_A` – extracts candidate triples from text.
+- `entity_linker` – maps mentions to canonical entities.
+- `kg_writer` – writes triples to a JSON file.
+- `verifier` – performs simple consistency checks.
+
+Each stub runs as a small FastAPI server. You can try one directly:
+
+```bash
+python -m micrographonia.tools.stubs.extractor_A
+# visit http://localhost:8001/docs
+```
+
+These services demonstrate the contract each tool must implement, acting as placeholders for future Gemma-based specialists.

--- a/micrographonia/tools/stubs/__init__.py
+++ b/micrographonia/tools/stubs/__init__.py
@@ -1,3 +1,5 @@
+"""Convenience imports for stub tool implementations used in tests."""
+
 from .extractor_A import run as extractor_A
 from .entity_linker import run as entity_linker
 from .verifier import run as verifier

--- a/micrographonia/tools/stubs/entity_linker.py
+++ b/micrographonia/tools/stubs/entity_linker.py
@@ -1,3 +1,8 @@
+"""Stub entity linker mapping mentions to lowercase identifiers."""
+
+
 def run(payload: dict) -> dict:
+    """Link each mention to a lower-case entity identifier."""
+
     entities = [{"mention": m, "entity": m.lower()} for m in payload["mentions"]]
     return {"entities": entities}

--- a/micrographonia/tools/stubs/extractor_A.py
+++ b/micrographonia/tools/stubs/extractor_A.py
@@ -1,4 +1,9 @@
+"""Stub mention extractor returning capitalised words."""
+
+
 def run(payload: dict) -> dict:
+    """Return a list of capitalised tokens from ``payload['text']``."""
+
     text: str = payload["text"]
     mentions = [w for w in text.split() if w and w[0].isupper()]
     return {"mentions": mentions}

--- a/micrographonia/tools/stubs/kg_writer.py
+++ b/micrographonia/tools/stubs/kg_writer.py
@@ -1,7 +1,12 @@
+"""Stub knowledge-graph writer that persists triples to disk."""
+
 import json
 from pathlib import Path
 
+
 def run(payload: dict) -> dict:
+    """Write triples to a JSON file and return its path."""
+
     path = Path(payload.get("path", "kg.json"))
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as fh:

--- a/micrographonia/tools/stubs/verifier.py
+++ b/micrographonia/tools/stubs/verifier.py
@@ -1,3 +1,8 @@
+"""Stub verifier producing trivial subject-predicate-object triples."""
+
+
 def run(payload: dict) -> dict:
+    """Convert entities into ``is`` triples."""
+
     triples = [[e["entity"], "is", e["mention"]] for e in payload["entities"]]
     return {"triples": triples}

--- a/registry/README.md
+++ b/registry/README.md
@@ -1,0 +1,18 @@
+# Tool Registry
+
+JSON manifests describing the available tools. These are loaded by the `Registry` class and referenced by the example plans and tests.
+
+## Structure
+Each manifest lives in `manifests/` and follows the schema expected by the runtime. Adding a new tool simply involves dropping a new manifest file.
+
+## Example
+```json
+{
+  "id": "kg_writer.v1",
+  "url": "http://localhost:8003/write",
+  "inputs": { "triples": "list", "namespace": "string" },
+  "outputs": { "path": "string" }
+}
+```
+
+Use these manifests to swap in real implementations or to point to running services.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,18 @@
+# Tests
+
+Unit tests covering the runtime engine, registry, SDK helpers and tool integrations.
+
+## Running
+Execute the full suite:
+
+```bash
+pytest
+```
+
+For a quicker signal during development run a subset:
+
+```bash
+pytest tests/test_runtime.py::test_simple_plan
+```
+
+The tests double as executable specification and can be extended as new tools or runtime features are added.


### PR DESCRIPTION
## Summary
- add README files for examples, package modules, registry and tests
- document runtime state and retry utilities
- annotate SDK helpers and stub tools with module docstrings
- expand component READMEs with motivation and usage examples

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5821df2bc8326b8938f766f6b15e1