### PR TITLE
feat: add model preflight loader for in-proc tools

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -24,3 +24,17 @@ python -m micrographonia.sdk.cli plan.run \
 ```
 
 Modify the YAML plan or dataset to adapt this flow to your own domain.
+
+### In‑process tool example
+
+The ``manual_plans/notes_inproc.yml`` plan demonstrates using an in‑process
+tool with a pre‑loaded model.  Validate the model availability before running:
+
+```bash
+python -m micrographonia.sdk.cli plan.check-models \
+  --plan examples/manual_plans/notes_inproc.yml \
+  --registry examples/registry/manifests
+```
+
+Running ``plan.run`` on the same plan will implicitly perform the pre‑flight
+check and reuse the cached model on subsequent runs.

--- a/examples/manual_plans/notes_inproc.yml
+++ b/examples/manual_plans/notes_inproc.yml
@@ -1,0 +1,6 @@
+version: "0.1"
+graph:
+  - id: extract
+    tool: extractor_A.v2
+    inputs:
+      text: "hello"

--- a/examples/registry/manifests/extractor_A.v2.json
+++ b/examples/registry/manifests/extractor_A.v2.json
@@ -1,0 +1,17 @@
+{
+  "name": "extractor_A",
+  "version": "v2",
+  "kind": "inproc",
+  "entrypoint": "examples.tools.extractor.factory",
+  "input_schema": {"type": "object", "required": ["text"], "properties": {"text": {"type": "string"}}, "additionalProperties": false},
+  "output_schema": {"type": "object", "required": ["triples"], "properties": {"triples": {"type": "array"}}, "additionalProperties": false},
+  "model": {
+    "base_id": "google/gemma-3-270m",
+    "adapter_uri": "hf://AmeetR/extractor-a-v2@9f3a5c1/adapter/",
+    "revision": "9f3a5c1",
+    "loader": "peft-lora",
+    "quant": "4bit",
+    "device_hint": "auto"
+  },
+  "tags": ["kg", "extract"]
+}

--- a/examples/tools/extractor.py
+++ b/examples/tools/extractor.py
@@ -1,0 +1,33 @@
+"""Example in-process extractor tool.
+
+This module demonstrates the required factory signature for in-process tools.
+The implementation is intentionally trivial and merely echoes an empty list of
+triples; real tools would apply a tokenizer and model to produce structured
+output.
+"""
+
+from __future__ import annotations
+
+from micrographonia.runtime.tools import Tool
+
+
+class ExtractorTool(Tool):
+    """Minimal example tool returning no triples."""
+
+    def __init__(self, manifest):
+        self.manifest = manifest
+
+    def invoke(self, payload: dict, timeout_s: float | None = None) -> dict:  # pragma: no cover - example
+        """Return an empty result regardless of *payload*.
+
+        The ``# pragma: no cover`` markers keep coverage noise low as these
+        examples serve purely as documentation.
+        """
+
+        return {"triples": []}
+
+
+def factory(manifest, loader, preloaded=None):
+    """Factory producing :class:`ExtractorTool` instances."""
+
+    return ExtractorTool(manifest)

--- a/micrographonia/registry/manifest.py
+++ b/micrographonia/registry/manifest.py
@@ -16,6 +16,8 @@ class ToolManifest:
     input_schema: Dict[str, Any]
     output_schema: Dict[str, Any]
     endpoint: Optional[str] = None
+    entrypoint: Optional[str] = None
+    model: Dict[str, Any] | None = None
     tags: list[str] | None = None
 
     @property

--- a/micrographonia/runtime/artifacts.py
+++ b/micrographonia/runtime/artifacts.py
@@ -72,6 +72,11 @@ class RunArtifacts:
         self._write(path, {"error": message})
         self.paths["nodes"].setdefault(node_id, {})["error"] = str(path)
 
+    def write_preflight_error(self, message: str, cls: str) -> None:
+        path = self.nodes_dir / "__preflight__.error.json"
+        self._write(path, {"error": message, "class": cls})
+        self.paths["nodes"]["__preflight__"] = {"error": str(path)}
+
     def write_metrics(self, metrics: Dict[str, Any]) -> None:
         path = self.root / "metrics.json"
         self._write(path, metrics)

--- a/micrographonia/runtime/constants.py
+++ b/micrographonia/runtime/constants.py
@@ -1,0 +1,44 @@
+"""Common enums and runtime constants."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class LoaderType(str, Enum):
+    """Supported model loader implementations."""
+
+    PEFT_LORA = "peft-lora"
+
+
+class Quantization(str, Enum):
+    """Quantization options for model loading."""
+
+    BITS4 = "4bit"
+    BITS8 = "8bit"
+
+
+class DeviceHint(str, Enum):
+    """Device placement hints."""
+
+    AUTO = "auto"
+    CPU = "cpu"
+    CUDA = "cuda"
+
+
+class AdapterScheme(str, Enum):
+    """Supported adapter URI schemes."""
+
+    HF = "hf://"
+    S3 = "s3://"
+    GS = "gs://"
+    FILE = "file://"
+
+
+ADAPTER_URI_SCHEMES = tuple(s.value for s in AdapterScheme)
+
+
+STUB_BASE_ID = "stub"
+
+
+STOP_REASON_PREFLIGHT = "error:Preflight"

--- a/micrographonia/runtime/errors.py
+++ b/micrographonia/runtime/errors.py
@@ -51,3 +51,7 @@ class BudgetError(MicrographiaError):
 
 class EngineError(MicrographiaError):
     """Raised for unexpected errors within the engine."""
+
+
+class ModelLoadError(MicrographiaError):
+    """Raised when model artifacts cannot be resolved or verified."""

--- a/micrographonia/runtime/model_loader.py
+++ b/micrographonia/runtime/model_loader.py
@@ -1,0 +1,140 @@
+"""Model loading utilities for in-process tools.
+
+The :class:`ModelLoader` resolves model adapter URIs from a variety of
+backends (Hugging Face, S3/GS buckets via ``fsspec`` or local files), verifies
+their integrity and attaches them to a base model.  A small content addressed
+cache avoids repeated downloads.  For test scenarios the loader understands the
+special ``base_id="stub"`` which returns inexpensive dummy objects instead of
+touching the real ``transformers`` stack.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+from pathlib import Path
+from typing import Tuple, Union
+
+import fsspec
+try:  # pragma: no cover - imported lazily for tests
+    from huggingface_hub import snapshot_download
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    from peft import PeftModel
+except Exception:  # pragma: no cover - tests may monkeypatch
+    snapshot_download = None  # type: ignore
+    AutoTokenizer = AutoModelForCausalLM = PeftModel = object  # type: ignore
+
+from .errors import ModelLoadError
+from .constants import (
+    AdapterScheme,
+    DeviceHint,
+    LoaderType,
+    Quantization,
+    STUB_BASE_ID,
+)
+
+
+class ModelLoader:
+    """Resolve model adapter URIs and attach adapters."""
+
+    def __init__(self, cache_dir: Path | None = None) -> None:
+        if cache_dir is None:
+            cache_dir = Path.home() / ".micrographia" / "model-cache"
+        self.cache_dir = Path(cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    def _bundle_hash(self, directory: Path) -> str:
+        """Return a combined SHA256 hash for all files under *directory*.
+
+        Each file digest is computed separately and concatenated before hashing
+        again.  This is stable across platforms and orderings.
+        """
+
+        digests = []
+        for path in sorted(p for p in directory.rglob("*") if p.is_file()):
+            digests.append(hashlib.sha256(path.read_bytes()).hexdigest())
+        blob = "".join(digests)
+        return hashlib.sha256(blob.encode()).hexdigest()
+
+    # ------------------------------------------------------------------
+    def _resolve_hf(self, uri: str, revision: str | None, dest: Path) -> Path:
+        """Resolve a Hugging Face ``hf://`` URI to a local directory."""
+
+        # uri format: hf://org/repo@rev/subdir/
+        path = uri[len(AdapterScheme.HF.value) :]
+        parts = path.split("/")
+        if len(parts) < 2:
+            raise ModelLoadError("invalid hf uri")
+        repo_part = "/".join(parts[:2])
+        subpath = "/".join(parts[2:]) if len(parts) > 2 else ""
+        if "@" in repo_part:
+            repo_id, rev_part = repo_part.split("@", 1)
+            revision = rev_part
+        else:
+            repo_id = repo_part
+        repo_dir = Path(snapshot_download(repo_id, revision=revision, local_dir=self.cache_dir))
+        return repo_dir / subpath if subpath else repo_dir
+
+    # ------------------------------------------------------------------
+    def _resolve_fs(self, uri: str, dest: Path) -> Path:
+        """Download an adapter from a generic filesystem URI."""
+
+        scheme, path = uri.split("://", 1)
+        fs = fsspec.filesystem(scheme)
+        fs.get(path, str(dest), recursive=True)
+        return dest
+
+    # ------------------------------------------------------------------
+    def load(
+        self,
+        *,
+        base_id: str,
+        adapter_uri: str,
+        revision: str | None = None,
+        sha256: str | None = None,
+        loader: Union[LoaderType, str] = LoaderType.PEFT_LORA,
+        quant: Union[Quantization, str, None] = None,
+        device_hint: Union[DeviceHint, str] = DeviceHint.AUTO,
+    ) -> Tuple[AutoTokenizer, AutoModelForCausalLM]:
+        """Resolve, verify, cache, and load a model."""
+        loader_enum = LoaderType(loader)
+        if loader_enum is not LoaderType.PEFT_LORA:
+            raise ModelLoadError(f"Unsupported loader: {loader}")
+
+        if base_id == STUB_BASE_ID:
+            class Dummy:
+                def eval(self):
+                    pass
+
+            return Dummy(), Dummy()
+
+        key = sha256 or hashlib.sha256(f"{adapter_uri}@{revision}".encode()).hexdigest()
+        local_dir = self.cache_dir / key
+        if not local_dir.exists():
+            tmp_dir = local_dir.with_suffix(".tmp")
+            tmp_dir.mkdir(parents=True, exist_ok=True)
+            if adapter_uri.startswith(AdapterScheme.HF.value):
+                src = self._resolve_hf(adapter_uri, revision, tmp_dir)
+                if src != tmp_dir:
+                    shutil.copytree(src, tmp_dir, dirs_exist_ok=True)
+            else:
+                self._resolve_fs(adapter_uri, tmp_dir)
+            tmp_dir.replace(local_dir)
+        if sha256:
+            digest = self._bundle_hash(local_dir)
+            if digest != sha256:
+                raise ModelLoadError("SHA mismatch")
+
+        tokenizer = AutoTokenizer.from_pretrained(base_id)
+        quant_enum = Quantization(quant) if quant is not None else None
+        device_enum = DeviceHint(device_hint)
+        model = AutoModelForCausalLM.from_pretrained(
+            base_id,
+            device_map="auto" if device_enum is DeviceHint.AUTO else None,
+            load_in_4bit=quant_enum is Quantization.BITS4,
+            load_in_8bit=quant_enum is Quantization.BITS8,
+        )
+        model = PeftModel.from_pretrained(model, str(local_dir))
+        model.eval()
+        return tokenizer, model

--- a/micrographonia/runtime/preflight.py
+++ b/micrographonia/runtime/preflight.py
@@ -1,0 +1,60 @@
+"""Pre-flight resolution of tools and model loading."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Dict
+
+from .tools import HttpTool, Tool
+from .model_loader import ModelLoader
+from ..registry.registry import Registry
+from ..sdk.plan_ir import Plan
+from .errors import EngineError, ModelLoadError, RegistryError
+
+
+def _import_entrypoint(path: str):
+    """Import ``path`` and return the referenced factory callable."""
+
+    module, func = path.rsplit(".", 1)
+    mod = importlib.import_module(module)
+    return getattr(mod, func)
+
+
+def preflight_build_tool_pool(
+    plan: Plan,
+    registry: Registry,
+    *,
+    loader: ModelLoader,
+    warmup: bool = True,
+) -> Dict[str, Tool]:
+    """Resolve all tools referenced by *plan* and return a tool pool."""
+
+    tools = {node.tool for node in plan.graph}
+    pool: Dict[str, Tool] = {}
+    for namever in tools:
+        manifest = registry.resolve(namever)
+        if manifest.kind == "http":
+            pool[namever] = HttpTool(manifest)
+            continue
+        if not manifest.model:
+            raise RegistryError("manifest.model missing")
+        try:
+            tok, model = loader.load(**manifest.model)
+        except ModelLoadError:
+            raise
+        factory = None
+        try:
+            factory = _import_entrypoint(manifest.entrypoint)
+        except Exception as exc:
+            raise EngineError(f"Cannot import {manifest.entrypoint}") from exc
+        try:
+            tool = factory(manifest, loader, preloaded=(tok, model))
+        except Exception as exc:
+            raise EngineError(f"Error instantiating tool {namever}") from exc
+        pool[namever] = tool
+        if warmup and hasattr(tool, "warmup"):
+            try:
+                tool.warmup()  # pragma: no cover - optional
+            except Exception:
+                pass
+    return pool

--- a/micrographonia/sdk/cli.py
+++ b/micrographonia/sdk/cli.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from enum import IntEnum
 
 import typer
 
 from .validate import load_plan, validate_plan
 from ..registry.registry import Registry
 from ..runtime.engine import run_plan
+from ..runtime.preflight import preflight_build_tool_pool
+from ..runtime.model_loader import ModelLoader
 from ..runtime.errors import (
     BudgetError,
     EngineError,
@@ -17,6 +20,8 @@ from ..runtime.errors import (
     PlanSchemaError,
     SchemaError,
     ToolCallError,
+    RegistryError,
+    ModelLoadError,
 )
 
 app = typer.Typer()
@@ -26,33 +31,29 @@ app.add_typer(plan_app, name="plan")
 app.add_typer(registry_app, name="registry")
 
 
+class ExitCode(IntEnum):
+    SUCCESS = 0
+    SCHEMA_ERROR = 12
+    TOOL_CALL_ERROR = 13
+    BUDGET_ERROR = 14
+    ENGINE_ERROR = 15
+
+
 EXIT_CODES = {
-    SchemaError: 12,
-    ToolCallError: 13,
-    BudgetError: 14,
-    PlanSchemaError: 15,
-    EngineError: 15,
+    SchemaError: ExitCode.SCHEMA_ERROR,
+    ToolCallError: ExitCode.TOOL_CALL_ERROR,
+    BudgetError: ExitCode.BUDGET_ERROR,
+    PlanSchemaError: ExitCode.ENGINE_ERROR,
+    EngineError: ExitCode.ENGINE_ERROR,
+    RegistryError: ExitCode.ENGINE_ERROR,
+    ModelLoadError: ExitCode.ENGINE_ERROR,
 }
 
 
 def _exit_err(exc: MicrographiaError) -> None:
-    code = EXIT_CODES.get(type(exc), 1)
+    code = int(EXIT_CODES.get(type(exc), 1))
     typer.echo(str(exc), err=True)
     raise typer.Exit(code)
-
-
-def _load_impls():
-    try:  # pragma: no cover - optional
-        from ..tools.stubs import extractor_A, entity_linker, verifier, kg_writer
-
-        return {
-            "extractor_A.v1": extractor_A,
-            "entity_linker.v1": entity_linker,
-            "verifier.v1": verifier,
-            "kg_writer.v1": kg_writer,
-        }
-    except Exception:  # pragma: no cover
-        return {}
 
 
 @plan_app.command("validate")
@@ -77,6 +78,7 @@ def plan_run(
     max_parallel: int | None = typer.Option(None, help="Override plan max_parallel"),
     cache_read: bool = typer.Option(True, help="Enable cache reads"),
     cache_write: bool = typer.Option(True, help="Enable cache writes"),
+    no_warmup: bool = typer.Option(False, help="Skip model warmup"),
     emit_summary: bool = typer.Option(False, help="Emit one-line summary"),
 ) -> None:
     try:
@@ -88,13 +90,14 @@ def plan_run(
             p,
             ctx,
             reg,
-            impls=_load_impls(),
             runs_dir=runs,
             run_id=run_id,
             resume=resume,
             max_parallel=max_parallel,
             cache_read=cache_read,
             cache_write=cache_write,
+            loader=ModelLoader(),
+            warmup=not no_warmup,
         )
     except MicrographiaError as exc:
         _exit_err(exc)
@@ -105,6 +108,22 @@ def plan_run(
         typer.echo(json.dumps(record, indent=2))
     if err:
         _exit_err(err)
+
+
+@plan_app.command("check-models")
+def plan_check_models(
+    plan: Path,
+    registry: Path,
+    no_warmup: bool = typer.Option(False, help="Skip model warmup"),
+) -> None:
+    try:
+        reg = Registry(registry)
+        p = load_plan(plan)
+        validate_plan(p, reg)
+        preflight_build_tool_pool(p, reg, loader=ModelLoader(), warmup=not no_warmup)
+    except MicrographiaError as exc:
+        _exit_err(exc)
+    typer.echo("ok")
 
 
 @registry_app.command("health")

--- a/micrographonia/tools/stubs/entity_linker.py
+++ b/micrographonia/tools/stubs/entity_linker.py
@@ -1,8 +1,14 @@
 """Stub entity linker mapping mentions to lowercase identifiers."""
 
+from micrographonia.runtime.tools import InprocTool
+
 
 def run(payload: dict) -> dict:
     """Link each mention to a lower-case entity identifier."""
 
     entities = [{"mention": m, "entity": m.lower()} for m in payload["mentions"]]
     return {"entities": entities}
+
+
+def factory(manifest, loader, preloaded=None):  # pragma: no cover - simple stub
+    return InprocTool(manifest, run)

--- a/micrographonia/tools/stubs/extractor_A.py
+++ b/micrographonia/tools/stubs/extractor_A.py
@@ -1,5 +1,7 @@
 """Stub mention extractor returning capitalised words."""
 
+from micrographonia.runtime.tools import InprocTool
+
 
 def run(payload: dict) -> dict:
     """Return a list of capitalised tokens from ``payload['text']``."""
@@ -7,3 +9,7 @@ def run(payload: dict) -> dict:
     text: str = payload["text"]
     mentions = [w for w in text.split() if w and w[0].isupper()]
     return {"mentions": mentions}
+
+
+def factory(manifest, loader, preloaded=None):  # pragma: no cover - simple stub
+    return InprocTool(manifest, run)

--- a/micrographonia/tools/stubs/kg_writer.py
+++ b/micrographonia/tools/stubs/kg_writer.py
@@ -3,6 +3,8 @@
 import json
 from pathlib import Path
 
+from micrographonia.runtime.tools import InprocTool
+
 
 def run(payload: dict) -> dict:
     """Write triples to a JSON file and return its path."""
@@ -12,3 +14,7 @@ def run(payload: dict) -> dict:
     with path.open("w", encoding="utf-8") as fh:
         json.dump({"triples": payload["triples"]}, fh, indent=2)
     return {"path": str(path)}
+
+
+def factory(manifest, loader, preloaded=None):  # pragma: no cover - simple stub
+    return InprocTool(manifest, run)

--- a/micrographonia/tools/stubs/verifier.py
+++ b/micrographonia/tools/stubs/verifier.py
@@ -1,8 +1,14 @@
 """Stub verifier producing trivial subject-predicate-object triples."""
 
+from micrographonia.runtime.tools import InprocTool
+
 
 def run(payload: dict) -> dict:
     """Convert entities into ``is`` triples."""
 
     triples = [[e["entity"], "is", e["mention"]] for e in payload["entities"]]
     return {"triples": triples}
+
+
+def factory(manifest, loader, preloaded=None):  # pragma: no cover - simple stub
+    return InprocTool(manifest, run)

--- a/registry/manifests/entity_linker.v1.json
+++ b/registry/manifests/entity_linker.v1.json
@@ -2,6 +2,7 @@
   "name": "entity_linker",
   "version": "v1",
   "kind": "inproc",
+  "entrypoint": "micrographonia.tools.stubs.entity_linker.factory",
   "input_schema": {
     "type": "object",
     "required": ["mentions"],
@@ -28,5 +29,11 @@
       }
     },
     "additionalProperties": false
+  }
+  ,
+  "model": {
+    "base_id": "stub",
+    "adapter_uri": "file://stub",
+    "loader": "peft-lora"
   }
 }

--- a/registry/manifests/extractor_A.v1.json
+++ b/registry/manifests/extractor_A.v1.json
@@ -2,6 +2,7 @@
   "name": "extractor_A",
   "version": "v1",
   "kind": "inproc",
+  "entrypoint": "micrographonia.tools.stubs.extractor_A.factory",
   "input_schema": {
     "type": "object",
     "required": ["text"],
@@ -15,5 +16,11 @@
       "mentions": {"type": "array", "items": {"type": "string"}}
     },
     "additionalProperties": false
+  }
+  ,
+  "model": {
+    "base_id": "stub",
+    "adapter_uri": "file://stub",
+    "loader": "peft-lora"
   }
 }

--- a/registry/manifests/kg_writer.v1.json
+++ b/registry/manifests/kg_writer.v1.json
@@ -2,6 +2,7 @@
   "name": "kg_writer",
   "version": "v1",
   "kind": "inproc",
+  "entrypoint": "micrographonia.tools.stubs.kg_writer.factory",
   "tags": ["side_effecting"],
   "input_schema": {
     "type": "object",
@@ -25,5 +26,11 @@
     "required": ["path"],
     "properties": {"path": {"type": "string"}},
     "additionalProperties": false
+  }
+  ,
+  "model": {
+    "base_id": "stub",
+    "adapter_uri": "file://stub",
+    "loader": "peft-lora"
   }
 }

--- a/registry/manifests/verifier.v1.json
+++ b/registry/manifests/verifier.v1.json
@@ -2,6 +2,7 @@
   "name": "verifier",
   "version": "v1",
   "kind": "inproc",
+  "entrypoint": "micrographonia.tools.stubs.verifier.factory",
   "input_schema": {
     "type": "object",
     "required": ["entities"],
@@ -36,5 +37,11 @@
       }
     },
     "additionalProperties": false
+  }
+  ,
+  "model": {
+    "base_id": "stub",
+    "adapter_uri": "file://stub",
+    "loader": "peft-lora"
   }
 }

--- a/tests/test_cli_summary.py
+++ b/tests/test_cli_summary.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
-from micrographonia.sdk.cli import app
+from micrographonia.sdk.cli import app, ExitCode
 
 REG_DIR = Path("registry/manifests").resolve()
 
@@ -35,7 +35,7 @@ def test_cli_emit_summary(tmp_path: Path) -> None:
         ],
         env=env,
     )
-    assert result.exit_code == 0
+    assert result.exit_code == ExitCode.SUCCESS
     data = json.loads(result.stdout.strip())
     assert data["ok"] is True
     assert data["stop_reason"] is None
@@ -66,6 +66,6 @@ def test_cli_exit_code_deadline(tmp_path: Path) -> None:
         ],
         env=env,
     )
-    assert result.exit_code == 14
+    assert result.exit_code == ExitCode.BUDGET_ERROR
     data = json.loads(result.stdout.strip())
     assert data["stop_reason"] == "deadline"

--- a/tests/test_manifest_models.py
+++ b/tests/test_manifest_models.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from micrographonia.registry.registry import Registry
+from micrographonia.runtime.errors import RegistryError
+from micrographonia.runtime.constants import LoaderType, AdapterScheme
+
+BASE = {
+    "name": "tool",
+    "version": "v1",
+    "kind": "inproc",
+    "entrypoint": "examples.tools.extractor.factory",
+    "input_schema": {"type": "object"},
+    "output_schema": {"type": "object"},
+    "model": {
+        "base_id": "b",
+        "adapter_uri": f"{AdapterScheme.HF.value}repo/adapter/",
+        "loader": LoaderType.PEFT_LORA.value,
+    },
+}
+
+
+def _write_manifest(tmp_path: Path, data: dict) -> Path:
+    path = tmp_path / "tool.v1.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_missing_base_id(tmp_path: Path):
+    data = json.loads(json.dumps(BASE))
+    del data["model"]["base_id"]
+    _write_manifest(tmp_path, data)
+    with pytest.raises(RegistryError):
+        Registry(tmp_path)
+
+
+def test_unknown_loader(tmp_path: Path):
+    data = json.loads(json.dumps(BASE))
+    data["model"]["loader"] = "bad-loader"
+    _write_manifest(tmp_path, data)
+    with pytest.raises(RegistryError):
+        Registry(tmp_path)
+
+
+def test_bad_scheme(tmp_path: Path):
+    data = json.loads(json.dumps(BASE))
+    data["model"]["adapter_uri"] = "ftp://server/path"
+    _write_manifest(tmp_path, data)
+    with pytest.raises(RegistryError):
+        Registry(tmp_path)

--- a/tests/test_mixed_tools_plan.py
+++ b/tests/test_mixed_tools_plan.py
@@ -1,0 +1,88 @@
+import json
+import types
+import sys
+
+import httpx
+
+from micrographonia.registry.registry import Registry
+from micrographonia.runtime.engine import run_plan
+from micrographonia.runtime.model_loader import ModelLoader
+from micrographonia.sdk.plan_ir import Plan, Node
+from micrographonia.runtime.constants import LoaderType, AdapterScheme, STUB_BASE_ID
+
+
+class DummyTool:
+    def __init__(self, manifest):
+        self.manifest = manifest
+
+    def invoke(self, payload, timeout_s=None):
+        return {"echo": payload}
+
+
+def factory(manifest, loader, preloaded=None):
+    return DummyTool(manifest)
+
+sys.modules["dummy_tool"] = types.ModuleType("dummy_tool")
+sys.modules["dummy_tool"].factory = factory
+
+
+def _write_manifest(path, data):
+    path.write_text(json.dumps(data))
+
+
+def test_mixed_plan(tmp_path, monkeypatch):
+    reg_dir = tmp_path / "reg"
+    reg_dir.mkdir()
+    adapter_dir = reg_dir / "adapter"
+    adapter_dir.mkdir()
+    _write_manifest(
+        reg_dir / "t.v1.json",
+        {
+            "name": "t",
+            "version": "v1",
+            "kind": "inproc",
+            "entrypoint": "dummy_tool.factory",
+            "input_schema": {"type": "object"},
+            "output_schema": {"type": "object"},
+            "model": {
+                "base_id": STUB_BASE_ID,
+                "adapter_uri": f"{AdapterScheme.FILE.value}{adapter_dir.as_posix()}",
+                "loader": LoaderType.PEFT_LORA.value,
+            },
+        },
+    )
+    _write_manifest(
+        reg_dir / "h.v1.json",
+        {
+            "name": "h",
+            "version": "v1",
+            "kind": "http",
+            "endpoint": "http://server/tool",
+            "input_schema": {"type": "object"},
+            "output_schema": {"type": "object"},
+        },
+    )
+
+    reg = Registry(reg_dir)
+
+    def fake_post(url, json=None, timeout=None):
+        class Resp:
+            status_code = 200
+
+            def json(self):
+                return {"echo": json}
+
+        return Resp()
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    plan = Plan(
+        version="0.1",
+        graph=[
+            Node(id="a", tool="t.v1", inputs={}),
+            Node(id="b", tool="h.v1", inputs={}),
+        ],
+    )
+    record, err = run_plan(plan, {}, reg, loader=ModelLoader(), warmup=False)
+    assert err is None
+    assert record["totals"]["tool_calls"] == 2

--- a/tests/test_model_loader_hf.py
+++ b/tests/test_model_loader_hf.py
@@ -1,0 +1,50 @@
+import types
+
+from micrographonia.runtime.model_loader import ModelLoader
+from micrographonia.runtime.constants import LoaderType, AdapterScheme
+
+
+class DummyModel:
+    def eval(self):
+        pass
+
+
+def test_hf_cache(monkeypatch, tmp_path):
+    """Ensure Hugging Face adapters are cached and not re-downloaded."""
+
+    calls = {"download": 0}
+
+    def fake_snapshot_download(repo_id, revision=None, local_dir=None):
+        calls["download"] += 1
+        d = tmp_path / "repo"
+        (d / "adapter").mkdir(parents=True, exist_ok=True)
+        (d / "adapter" / "a.txt").write_text("x")
+        return str(d)
+
+    monkeypatch.setattr(
+        "micrographonia.runtime.model_loader.snapshot_download", fake_snapshot_download
+    )
+    monkeypatch.setattr(
+        "micrographonia.runtime.model_loader.AutoTokenizer",
+        types.SimpleNamespace(from_pretrained=lambda *_a, **_k: "tok"),
+    )
+    monkeypatch.setattr(
+        "micrographonia.runtime.model_loader.AutoModelForCausalLM",
+        types.SimpleNamespace(from_pretrained=lambda *_a, **_k: DummyModel()),
+    )
+    monkeypatch.setattr(
+        "micrographonia.runtime.model_loader.PeftModel",
+        types.SimpleNamespace(from_pretrained=lambda base, dir: DummyModel()),
+    )
+
+    loader = ModelLoader(cache_dir=tmp_path / "cache")
+    cfg = {
+        "base_id": "b",
+        "adapter_uri": f"{AdapterScheme.HF.value}org/repo@rev/adapter/",
+        "revision": "rev",
+        "loader": LoaderType.PEFT_LORA.value,
+    }
+    loader.load(**cfg)
+    assert calls["download"] == 1
+    loader.load(**cfg)
+    assert calls["download"] == 1

--- a/tests/test_model_loader_s3.py
+++ b/tests/test_model_loader_s3.py
@@ -1,0 +1,41 @@
+import types
+
+import fsspec
+import pytest
+
+from micrographonia.runtime.model_loader import ModelLoader
+from micrographonia.runtime.errors import ModelLoadError
+from micrographonia.runtime.constants import LoaderType, AdapterScheme
+
+
+def test_s3_sha_mismatch(monkeypatch, tmp_path):
+    fs = fsspec.filesystem("memory")
+    fs.mkdirs("bucket/adapter")
+    fs.open("bucket/adapter/a.txt", "wb").write(b"hello")
+
+    orig_fs = fsspec.filesystem
+    monkeypatch.setattr(
+        fsspec, "filesystem", lambda protocol, **kw: fs if protocol == "s3" else orig_fs(protocol, **kw)
+    )
+    monkeypatch.setattr(
+        "micrographonia.runtime.model_loader.AutoTokenizer",
+        types.SimpleNamespace(from_pretrained=lambda *_a, **_k: "tok"),
+    )
+    monkeypatch.setattr(
+        "micrographonia.runtime.model_loader.AutoModelForCausalLM",
+        types.SimpleNamespace(from_pretrained=lambda *_a, **_k: object()),
+    )
+    monkeypatch.setattr(
+        "micrographonia.runtime.model_loader.PeftModel",
+        types.SimpleNamespace(from_pretrained=lambda base, dir: object()),
+    )
+
+    loader = ModelLoader(cache_dir=tmp_path / "cache")
+    cfg = {
+        "base_id": "b",
+        "adapter_uri": f"{AdapterScheme.S3.value}bucket/adapter",
+        "loader": LoaderType.PEFT_LORA.value,
+        "sha256": "deadbeef",
+    }
+    with pytest.raises(ModelLoadError):
+        loader.load(**cfg)

--- a/tests/test_preflight_error_artifact.py
+++ b/tests/test_preflight_error_artifact.py
@@ -1,0 +1,78 @@
+import json
+import types
+import sys
+from pathlib import Path
+
+import pytest
+
+from micrographonia.registry.registry import Registry
+from micrographonia.runtime.engine import run_plan
+from micrographonia.runtime.errors import ModelLoadError
+from micrographonia.runtime.model_loader import ModelLoader
+from micrographonia.sdk.plan_ir import Plan, Node
+from micrographonia.runtime.constants import LoaderType, AdapterScheme
+
+
+class DummyTool:
+    def __init__(self, manifest):
+        self.manifest = manifest
+
+    def invoke(self, payload, timeout_s=None):
+        return {}
+
+
+def factory(manifest, loader, preloaded=None):
+    return DummyTool(manifest)
+
+sys.modules["preflight_tool"] = types.ModuleType("preflight_tool")
+sys.modules["preflight_tool"].factory = factory
+
+
+def _write_manifest(tmp_path: Path):
+    adapter_dir = tmp_path / "adapter"
+    adapter_uri = f"{AdapterScheme.FILE.value}{adapter_dir.as_posix()}"
+    data = {
+        "name": "t",
+        "version": "v1",
+        "kind": "inproc",
+        "entrypoint": "preflight_tool.factory",
+        "input_schema": {"type": "object"},
+        "output_schema": {"type": "object"},
+        "model": {
+            "base_id": "b",
+            "adapter_uri": adapter_uri,
+            "loader": LoaderType.PEFT_LORA.value,
+            "sha256": "deadbeef",
+        },
+    }
+    path = tmp_path / "t.v1.json"
+    path.write_text(json.dumps(data))
+    return adapter_dir
+
+
+def test_preflight_error(tmp_path, monkeypatch):
+    reg_dir = tmp_path / "reg"
+    reg_dir.mkdir()
+    adapter_dir = _write_manifest(reg_dir)
+    adapter_dir.mkdir()
+    reg = Registry(reg_dir)
+
+    plan = Plan(version="0.1", graph=[Node(id="a", tool="t.v1", inputs={})])
+    monkeypatch.setattr(
+        "micrographonia.runtime.model_loader.AutoTokenizer",
+        types.SimpleNamespace(from_pretrained=lambda *_a, **_k: "tok"),
+    )
+    monkeypatch.setattr(
+        "micrographonia.runtime.model_loader.AutoModelForCausalLM",
+        types.SimpleNamespace(from_pretrained=lambda *_a, **_k: object()),
+    )
+    monkeypatch.setattr(
+        "micrographonia.runtime.model_loader.PeftModel",
+        types.SimpleNamespace(from_pretrained=lambda base, dir: object()),
+    )
+    record, err = run_plan(plan, {}, reg, loader=ModelLoader(), warmup=False)
+    assert isinstance(err, ModelLoadError)
+    err_path = Path(record["artifacts"]["nodes"]["__preflight__"]["error"])
+    assert err_path.exists()
+    data = json.loads(err_path.read_text())
+    assert data["class"] == "ModelLoadError"

--- a/tests/test_preflight_failfast.py
+++ b/tests/test_preflight_failfast.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+import json
+import pytest
+
+from micrographonia.runtime.preflight import preflight_build_tool_pool
+from micrographonia.runtime.model_loader import ModelLoader
+from micrographonia.registry.registry import Registry
+from micrographonia.runtime.errors import EngineError, RegistryError
+from micrographonia.sdk.plan_ir import Plan, Node
+from micrographonia.runtime.constants import LoaderType, AdapterScheme, STUB_BASE_ID
+
+
+def _write_manifest(tmp_path: Path, data: dict) -> None:
+    path = tmp_path / f"{data['name']}.{data['version']}.json"
+    path.write_text(json.dumps(data))
+
+
+BASE_MANIFEST = {
+    "name": "t",
+    "version": "v1",
+    "kind": "inproc",
+    "entrypoint": "not.a.module.factory",
+    "input_schema": {"type": "object"},
+    "output_schema": {"type": "object"},
+    "model": {
+        "base_id": STUB_BASE_ID,
+        "adapter_uri": "",  # filled in test
+        "loader": LoaderType.PEFT_LORA.value,
+    },
+}
+
+
+def test_bad_entrypoint(tmp_path: Path, monkeypatch):
+    adapter_dir = tmp_path / "adapter"
+    adapter_dir.mkdir()
+    manifest = json.loads(json.dumps(BASE_MANIFEST))
+    manifest["model"]["adapter_uri"] = f"{AdapterScheme.FILE.value}{adapter_dir.as_posix()}"
+    _write_manifest(tmp_path, manifest)
+    reg = Registry(tmp_path)
+    plan = Plan(version="0.1", graph=[Node(id="n", tool="t.v1", inputs={})])
+    with pytest.raises(EngineError):
+        preflight_build_tool_pool(plan, reg, loader=ModelLoader(), warmup=False)
+
+
+def test_missing_model(tmp_path: Path):
+    bad = dict(BASE_MANIFEST)
+    bad["model"] = None
+    _write_manifest(tmp_path, bad)
+    with pytest.raises(RegistryError):
+        Registry(tmp_path)


### PR DESCRIPTION
## Summary
- document in-proc model block and pre-flight flow in READMEs and example tool
- add module docstrings for model loader and preflight resolver
- expand tests to cover adapter caching, SHA mismatch and pre-flight error handling without mocking core loader
- centralize runtime constants into enums for loaders, devices, quantization, URI schemes, exit codes, and stop reasons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5bfeb80648326bae5eba475468bfa