### PR TITLE
Add workflow-safe runner with exit codes and metrics

### DIFF
--- a/micrographonia/core/__init__.py
+++ b/micrographonia/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core utilities for Micrographia runner."""
+from .runner import run
+from . import constants
+
+__all__ = ["run", "constants"]

--- a/micrographonia/core/constants.py
+++ b/micrographonia/core/constants.py
@@ -1,0 +1,37 @@
+"""Shared string constants for runner outputs."""
+
+RUNS_DIR = "runs"
+META_FILE = "meta.json"
+METRICS_FILE = "metrics.json"
+TIMELINE_FILE = "timeline.json"
+LOG_FILE = "logs.txt"
+
+# stop reasons
+COMPLETED = "completed"
+PREFLIGHT_FAILED = "preflight_failed"
+RUNTIME_ERROR = "runtime_error"
+INVALID_PLAN = "invalid_plan"
+PLAN_MISMATCH = "plan_mismatch"
+RESUME_NOT_SUPPORTED = "resume_not_supported"
+INTERRUPTED = "interrupted"
+
+# timeline statuses
+STATUS_OK = "ok"
+STATUS_FAILED = "failed"
+
+__all__ = [
+    "RUNS_DIR",
+    "META_FILE",
+    "METRICS_FILE",
+    "TIMELINE_FILE",
+    "LOG_FILE",
+    "COMPLETED",
+    "PREFLIGHT_FAILED",
+    "RUNTIME_ERROR",
+    "INVALID_PLAN",
+    "PLAN_MISMATCH",
+    "RESUME_NOT_SUPPORTED",
+    "INTERRUPTED",
+    "STATUS_OK",
+    "STATUS_FAILED",
+]

--- a/micrographonia/core/exit_codes.py
+++ b/micrographonia/core/exit_codes.py
@@ -1,0 +1,17 @@
+"""Exit code constants for the Micrographia runner."""
+
+SUCCESS = 0
+RUNTIME_FAILURE = 1
+PREFLIGHT_FAILURE = 2
+PLAN_MISMATCH = 3
+INVALID_PLAN = 4
+INTERRUPTED = 130
+
+__all__ = [
+    "SUCCESS",
+    "RUNTIME_FAILURE",
+    "PREFLIGHT_FAILURE",
+    "PLAN_MISMATCH",
+    "INVALID_PLAN",
+    "INTERRUPTED",
+]

--- a/micrographonia/core/runner.py
+++ b/micrographonia/core/runner.py
@@ -1,0 +1,233 @@
+"""Simple workflow runner with deterministic outputs.
+
+This implementation is intentionally lightweight and only aims to provide the
+behaviour required for the unit tests in this kata.  It supports run
+identifiers, hashing of the plan and registry files, exit codes and writing
+metrics/timeline/log files.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+from . import exit_codes
+from . import constants
+from .utils import sha256_file
+
+ISO = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+@dataclass
+class NodeResult:
+    name: str
+    start: datetime
+    end: datetime
+    status: str
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _setup_logger(log_path: Path, verbose: bool) -> logging.Logger:
+    logger = logging.getLogger(f"runner.{id(log_path)}")
+    logger.setLevel(logging.INFO)
+    logger.handlers = []
+    fmt = logging.Formatter("[%(asctime)s] [%(levelname)s] %(message)s")
+    file_handler = logging.FileHandler(log_path)
+    file_handler.setFormatter(fmt)
+    logger.addHandler(file_handler)
+    if verbose:
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(fmt)
+        logger.addHandler(stream_handler)
+    return logger
+
+
+def load_plan(path: Path) -> Dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict) or "nodes" not in data or not isinstance(data["nodes"], list):
+        raise ValueError("invalid plan structure")
+    return data
+
+
+def load_registry(path: Path) -> Dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError("invalid registry structure")
+    return data
+
+
+def preflight_load(registry: Dict[str, Any]) -> None:
+    # extremely small simulation: if registry contains key ``bad`` then fail
+    if registry.get("bad"):
+        raise RuntimeError("bad registry")
+
+
+def execute_node(node: Dict[str, Any]) -> None:
+    if node.get("behavior") == "fail":
+        raise RuntimeError("node failed")
+    # any other behaviour is treated as success
+
+
+def run(
+    plan_path: str | Path,
+    registry_path: str | Path,
+    run_id: str | None = None,
+    resume_run_id: str | None = None,
+    emit_summary_json: bool = False,
+    verbose: bool = False,
+) -> int:
+    """Execute the plan and return an exit code."""
+
+    plan_path = Path(plan_path)
+    registry_path = Path(registry_path)
+
+    if resume_run_id:
+        run_id = resume_run_id
+        resume = True
+    else:
+        resume = False
+        run_id = run_id or str(uuid.uuid4())
+
+    outdir = Path(constants.RUNS_DIR) / run_id
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    plan_hash = sha256_file(plan_path)
+    registry_hash = sha256_file(registry_path)
+
+    meta = {
+        "run_id": run_id,
+        "plan_path": str(plan_path),
+        "registry_path": str(registry_path),
+        "plan_hash": plan_hash,
+        "registry_hash": registry_hash,
+        "created_at": _now().strftime(ISO),
+        "version": "micrographia@0.0-test",
+    }
+    meta_path = outdir / constants.META_FILE
+    if not resume:
+        meta_path.write_text(json.dumps(meta, indent=2))
+
+    started_at = _now()
+    logger = _setup_logger(outdir / constants.LOG_FILE, verbose)
+    timeline: List[NodeResult] = []
+    plan_nodes_total = 0
+    nodes_ok = 0
+
+    def stop(code: int, reason: str, *, error: str | None = None, extra: Dict[str, Any] | None = None) -> int:
+        ended = _now()
+        duration_ms = int((ended - started_at).total_seconds() * 1000)
+        metrics: Dict[str, Any] = {
+            "ok": code == exit_codes.SUCCESS,
+            "exit_code": code,
+            "stop_reason": reason,
+            "started_at": started_at.strftime(ISO),
+            "ended_at": ended.strftime(ISO),
+            "duration_ms": duration_ms,
+            "plan_hash": plan_hash,
+            "registry_hash": registry_hash,
+            "totals": {
+                "nodes_total": plan_nodes_total,
+                "nodes_ok": nodes_ok,
+                "nodes_failed": len([t for t in timeline if t.status == constants.STATUS_FAILED]),
+                "tool_calls": 0,
+                "retries": 0,
+                "cache_hits": 0,
+            },
+        }
+        if extra:
+            metrics.update(extra)
+        metrics_path = outdir / constants.METRICS_FILE
+        metrics_path.write_text(json.dumps(metrics, indent=2))
+        timeline_path = outdir / constants.TIMELINE_FILE
+        tl = [
+            {
+                "node": t.name,
+                "start": t.start.strftime(ISO),
+                "end": t.end.strftime(ISO),
+                "status": t.status,
+            }
+            for t in timeline
+        ]
+        timeline_path.write_text(json.dumps(tl, indent=2))
+        if emit_summary_json:
+            summary = {
+                "run_id": run_id,
+                "stop_reason": reason,
+                "exit_code": code,
+                "plan_hash": plan_hash,
+                "registry_hash": registry_hash,
+            }
+            print(json.dumps(summary))
+        return code
+
+    if resume:
+        if meta_path.exists():
+            try:
+                existing = json.loads(meta_path.read_text())
+            except Exception:
+                existing = {}
+            if existing.get("plan_hash") != plan_hash or existing.get("registry_hash") != registry_hash:
+                return stop(
+                    exit_codes.PLAN_MISMATCH,
+                    constants.PLAN_MISMATCH,
+                    extra={
+                        "resume": {
+                            "requested_run_id": run_id,
+                            "existing_plan_hash": existing.get("plan_hash"),
+                            "existing_registry_hash": existing.get("registry_hash"),
+                        }
+                    },
+                )
+            return stop(exit_codes.PLAN_MISMATCH, constants.RESUME_NOT_SUPPORTED)
+        else:
+            return stop(exit_codes.PLAN_MISMATCH, constants.PLAN_MISMATCH)
+
+    try:
+        plan = load_plan(plan_path)
+        registry = load_registry(registry_path)
+        plan_nodes_total = len(plan["nodes"])
+    except Exception:
+        return stop(exit_codes.INVALID_PLAN, constants.INVALID_PLAN)
+
+    try:
+        preflight_load(registry)
+    except Exception as exc:
+        logger.error("preflight failed: %s", exc)
+        return stop(exit_codes.PREFLIGHT_FAILURE, constants.PREFLIGHT_FAILED)
+
+    try:
+        for node in plan["nodes"]:
+            start = _now()
+            try:
+                execute_node(node)
+                status = constants.STATUS_OK
+                nodes_ok += 1
+                logger.info("node %s completed", node.get("name"))
+            except KeyboardInterrupt:
+                status = constants.STATUS_FAILED
+                end = _now()
+                timeline.append(NodeResult(node.get("name", ""), start, end, status))
+                raise
+            except Exception as exc:
+                status = constants.STATUS_FAILED
+                end = _now()
+                timeline.append(NodeResult(node.get("name", ""), start, end, status))
+                logger.error("node %s failed: %s", node.get("name"), exc)
+                raise
+            else:
+                end = _now()
+                timeline.append(NodeResult(node.get("name", ""), start, end, status))
+        return stop(exit_codes.SUCCESS, constants.COMPLETED)
+    except KeyboardInterrupt:
+        return stop(exit_codes.INTERRUPTED, constants.INTERRUPTED)
+    except Exception:
+        return stop(exit_codes.RUNTIME_FAILURE, constants.RUNTIME_ERROR)

--- a/micrographonia/core/utils/__init__.py
+++ b/micrographonia/core/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility helpers for core module."""
+from .hash import sha256_file
+__all__ = ["sha256_file"]

--- a/micrographonia/core/utils/hash.py
+++ b/micrographonia/core/utils/hash.py
@@ -1,0 +1,18 @@
+"""Hash helpers."""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+def sha256_file(path: str | Path) -> str:
+    """Return a sha256 digest for the given file.
+
+    The return format is ``"sha256:<hex>"`` which mirrors docker style hashes.
+    """
+    p = Path(path)
+    h = hashlib.sha256()
+    with p.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return f"sha256:{h.hexdigest()}"

--- a/tests/test_runner_exit_codes.py
+++ b/tests/test_runner_exit_codes.py
@@ -1,0 +1,73 @@
+import json
+import os
+from pathlib import Path
+
+from micrographonia.core import run
+from micrographonia.core import exit_codes
+from micrographonia.core import constants
+
+
+def write_plan(path: Path, nodes):
+    plan = {"nodes": nodes}
+    path.write_text(json.dumps(plan))
+    return path
+
+
+def write_registry(path: Path, content=None):
+    data = content if content is not None else {}
+    path.write_text(json.dumps(data))
+    return path
+
+
+class chdir:
+    def __init__(self, path):
+        self.path = path
+        self.old = None
+
+    def __enter__(self):
+        self.old = os.getcwd()
+        os.chdir(self.path)
+
+    def __exit__(self, exc_type, exc, tb):
+        os.chdir(self.old)
+
+
+def test_success_exit_code(tmp_path):
+    plan = write_plan(tmp_path / "plan.json", [{"name": "n1"}])
+    registry = write_registry(tmp_path / "reg.json")
+    with chdir(tmp_path):
+        code = run(plan, registry, run_id="run-success")
+        assert code == exit_codes.SUCCESS
+        metrics = json.loads((tmp_path / constants.RUNS_DIR / "run-success" / constants.METRICS_FILE).read_text())
+        assert metrics["stop_reason"] == constants.COMPLETED
+
+
+def test_preflight_failure_exit_code(tmp_path):
+    plan = write_plan(tmp_path / "plan.json", [{"name": "n1"}])
+    registry = write_registry(tmp_path / "reg.json", {"bad": True})
+    with chdir(tmp_path):
+        code = run(plan, registry, run_id="run-preflight")
+        assert code == exit_codes.PREFLIGHT_FAILURE
+        metrics = json.loads((tmp_path / constants.RUNS_DIR / "run-preflight" / constants.METRICS_FILE).read_text())
+        assert metrics["stop_reason"] == constants.PREFLIGHT_FAILED
+
+
+def test_runtime_failure_exit_code(tmp_path):
+    plan = write_plan(tmp_path / "plan.json", [{"name": "ok"}, {"name": "bad", "behavior": "fail"}])
+    registry = write_registry(tmp_path / "reg.json")
+    with chdir(tmp_path):
+        code = run(plan, registry, run_id="run-runtime")
+        assert code == exit_codes.RUNTIME_FAILURE
+        metrics = json.loads((tmp_path / constants.RUNS_DIR / "run-runtime" / constants.METRICS_FILE).read_text())
+        assert metrics["stop_reason"] == constants.RUNTIME_ERROR
+
+
+def test_invalid_plan_exit_code(tmp_path):
+    plan = tmp_path / "plan.json"
+    plan.write_text("not json")
+    registry = write_registry(tmp_path / "reg.json")
+    with chdir(tmp_path):
+        code = run(plan, registry, run_id="run-invalid")
+        assert code == exit_codes.INVALID_PLAN
+        metrics = json.loads((tmp_path / constants.RUNS_DIR / "run-invalid" / constants.METRICS_FILE).read_text())
+        assert metrics["stop_reason"] == constants.INVALID_PLAN


### PR DESCRIPTION
## Summary
- add exit code constants for workflow-safe plan runs
- implement deterministic runner with run IDs, hashing, metrics/timeline/logs and summary JSON
- cover runner exit code behavior with unit tests
- centralize shared runner strings to avoid magic values

## Testing
- `pytest tests/test_runner_exit_codes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6c90033d88326a6b8f9ae1eb73cea