### PR TITLE
Add fsspec dependency for model loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ requires-python = ">=3.11"
 dependencies = [
     "jsonschema>=4.17",
     "httpx>=0.25",
+    "fsspec>=2023.9",
     "typer>=0.9",
     "pyyaml>=6.0",
 ]


### PR DESCRIPTION
## Summary
- include fsspec in project dependencies so model loader tests run

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7204a64dc8326ace789949e22d6c1