### PR TITLE
Fix package discovery for registry directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,10 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 
+[tool.setuptools.packages.find]
+include = ["micrographonia*"]
+exclude = ["registry*"]
+
 [tool.ruff]
 line-length = 88
 target-version = "py311"


### PR DESCRIPTION
## Summary
- limit setuptools package discovery to the `micrographonia` package and exclude the `registry` directory

## Testing
- `python -m pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a722de9c108326bafc89c6bc9b00b0