### PR TITLE
Fix package discovery and CI ruff invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,5 @@ jobs:
         with:
           python-version: "3.11"
       - run: pip install . pytest ruff
-      - run: ruff .
+      - run: ruff check .
       - run: pytest -q

--- a/micrographonia/finetune/data/plugins/notes_kg.py
+++ b/micrographonia/finetune/data/plugins/notes_kg.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Dict
 
-from .base import TaskPlugin, register
+from .base import register
 
 
 @dataclass

--- a/micrographonia/runtime/engine.py
+++ b/micrographonia/runtime/engine.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Async execution engine for Micrographia.
 
 This module provides :func:`run_plan` which executes a plan described by the
@@ -10,9 +8,10 @@ runs.  The goal of the implementation is not to be feature complete but to
 provide the behaviour required by the tests in this kata.
 """
 
+from __future__ import annotations
+
 import asyncio
 import hashlib
-import json
 import time
 import datetime as _dt
 from dataclasses import asdict
@@ -27,10 +26,7 @@ from .concurrency import ConcurrencyManager
 from .errors import (
     BudgetError,
     EngineError,
-    ModelLoadError,
     MicrographiaError,
-    PlanSchemaError,
-    RegistryError,
     SchemaError,
     ToolCallError,
 )

--- a/micrographonia/runtime/retry.py
+++ b/micrographonia/runtime/retry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
-from typing import Iterable, List, Sequence
+from typing import List, Sequence
 
 from .errors import EngineError, SchemaError, ToolCallError
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,10 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 
+[tool.setuptools.packages.find]
+include = ["micrographonia*"]
+exclude = ["registry*"]
+
 [tool.ruff]
 line-length = 88
 target-version = "py311"

--- a/tests/test_engine_budget_deadline.py
+++ b/tests/test_engine_budget_deadline.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
-import pytest
-
 from micrographonia.registry.registry import Registry
 from micrographonia.sdk.plan_ir import Plan, Node, Budget
 from micrographonia.runtime.engine import run_plan

--- a/tests/test_plan_validation.py
+++ b/tests/test_plan_validation.py
@@ -56,7 +56,6 @@ def test_cycle(tmp_path: Path) -> None:
 
 
 def test_invalid_execution_and_retry(tmp_path: Path) -> None:
-    reg = Registry(REG_DIR)
     data = yaml.safe_load(PLAN_PATH.read_text())
     data["execution"] = {"max_parallel": 0}
     path = _write_plan(tmp_path, data)

--- a/tests/test_preflight_error_artifact.py
+++ b/tests/test_preflight_error_artifact.py
@@ -3,8 +3,6 @@ import types
 import sys
 from pathlib import Path
 
-import pytest
-
 from micrographonia.registry.registry import Registry
 from micrographonia.runtime.engine import run_plan
 from micrographonia.runtime.errors import ModelLoadError

--- a/tests/test_preflight_failfast.py
+++ b/tests/test_preflight_failfast.py
@@ -1,7 +1,5 @@
 import json
 from pathlib import Path
-
-import json
 import pytest
 
 from micrographonia.runtime.preflight import preflight_build_tool_pool


### PR DESCRIPTION
## Summary
- limit setuptools discovery to the `micrographonia` package and exclude the `registry` directory
- run `ruff check` in CI and clean up unused imports for lint compliance

## Testing
- `python -m pip install -e . --force-reinstall --no-deps`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a722de9c108326bafc89c6bc9b00b0