### PR TITLE
feat: add training and evaluation pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 
+[project.scripts]
+micrographonia = "symphonia.sdk.cli:app"
+
 [tool.setuptools.packages.find]
 include = ["symphonia*"]
 exclude = ["registry*"]

--- a/symphonia/finetune/cli.py
+++ b/symphonia/finetune/cli.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 import typer
 
+from .common.identity import stable_id
+from .common.validation import validate_record
 from .data.plugins.base import get_plugin
 
 app = typer.Typer(help="Finetuning utilities")
@@ -48,6 +50,10 @@ def datagen_seed(task: str, out: Path) -> None:
     out.parent.mkdir(parents=True, exist_ok=True)
     with out.open("w", encoding="utf-8") as f:
         for row in examples:
+            ok, err = validate_record(row, plugin, require_json=plugin.schema() is not None)
+            if not ok:
+                raise typer.BadParameter(f"invalid record: {err}")
+            row["id"] = stable_id(row)
             json.dump(row, f)
             f.write("\n")
 

--- a/symphonia/finetune/common/__init__.py
+++ b/symphonia/finetune/common/__init__.py
@@ -1,0 +1,1 @@
+"""Common helpers for finetuning utilities."""

--- a/symphonia/finetune/common/identity.py
+++ b/symphonia/finetune/common/identity.py
@@ -1,0 +1,41 @@
+"""Stable identity helpers for dataset records."""
+from __future__ import annotations
+
+import hashlib
+import json
+
+
+def stable_id(rec: dict) -> str:
+    """Return a deterministic identifier for *rec*.
+
+    The identifier is the first 16 hex characters of the SHA256 hash over
+    the minified JSON representation of the record's ``input`` and
+    ``target`` fields with keys sorted. This ensures that identical records
+    across runs yield the same id irrespective of key ordering."""
+
+    payload = json.dumps({"input": rec.get("input"), "target": rec.get("target")},
+                          sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def bucket(rec_id: str) -> int:
+    """Map ``rec_id`` to a deterministic bucket in ``[0, 99]``.
+
+    The implementation uses SHA1 hashing which is sufficient for the small
+    datasets used in tests."""
+
+    return int(hashlib.sha1(rec_id.encode("utf-8")).hexdigest(), 16) % 100
+
+
+def split_for_id(rec_id: str) -> str:
+    """Return the dataset split for ``rec_id``.
+
+    The default partitioning uses 90% train, 5% val and 5% test buckets and
+    is deterministic across runs."""
+
+    b = bucket(rec_id)
+    if b < 90:
+        return "train"
+    if b < 95:
+        return "val"
+    return "test"

--- a/symphonia/finetune/common/validation.py
+++ b/symphonia/finetune/common/validation.py
@@ -1,0 +1,48 @@
+"""Record validation helpers."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+import json
+from jsonschema import Draft202012Validator, ValidationError
+
+from ..data.plugins.base import TaskPlugin
+
+# Load and cache the base interaction schema
+_SCHEMA_PATH = Path(__file__).resolve().parents[1] / "data" / "schemas" / "interaction_v1.json"
+with _SCHEMA_PATH.open("r", encoding="utf-8") as _f:
+    _INTERACTION_SCHEMA = json.load(_f)
+_INTERACTION_VALIDATOR = Draft202012Validator(_INTERACTION_SCHEMA)
+
+
+def validate_record(rec: dict, plugin: TaskPlugin, require_json: bool) -> Tuple[bool, str | None]:
+    """Validate a dataset *rec* against base and plugin schemas.
+
+    Returns ``(True, None)`` if valid, otherwise ``(False, reason)`` describing
+    the failure. ``require_json`` enforces presence of ``target.json`` when the
+    plugin declares a schema.
+    """
+
+    try:
+        _INTERACTION_VALIDATOR.validate(rec)
+    except ValidationError as exc:  # pragma: no cover - jsonschema detail
+        return False, str(exc)
+
+    if "prompt" not in rec.get("input", {}):
+        return False, "missing input.prompt"
+
+    target = rec.get("target", {})
+    if "text" not in target and "json" not in target:
+        return False, "target must include text or json"
+
+    schema = plugin.schema()
+    if schema and (require_json or "json" in target):
+        if "json" not in target:
+            return False, "target.json required"
+        try:
+            Draft202012Validator(schema).validate(target["json"])
+        except ValidationError as exc:  # pragma: no cover - detail
+            return False, f"target.json invalid: {exc.message}"
+
+    return True, None

--- a/symphonia/finetune/tests/test_splits_deterministic.py
+++ b/symphonia/finetune/tests/test_splits_deterministic.py
@@ -1,0 +1,9 @@
+from symphonia.finetune.common.identity import stable_id, split_for_id
+
+
+def test_splits_deterministic() -> None:
+    rec = {"input": {"prompt": "hello"}, "target": {"text": "world"}}
+    rec_id1 = stable_id(rec)
+    rec_id2 = stable_id(rec)
+    assert rec_id1 == rec_id2
+    assert split_for_id(rec_id1) == split_for_id(rec_id2)

--- a/symphonia/finetune/tests/test_validation_strict.py
+++ b/symphonia/finetune/tests/test_validation_strict.py
@@ -1,0 +1,37 @@
+from symphonia.finetune.common.validation import validate_record
+from symphonia.finetune.data.plugins.notes_kg import plugin
+
+
+def base_record() -> dict:
+    """Return a minimal valid record for ``notes_kg``."""
+
+    return {
+        "id": "x",
+        "source": "seed",
+        "input": {"prompt": "hi"},
+        "target": {"text": "x"},
+        "meta": {"task": "notes_kg"},
+    }
+
+
+def test_missing_prompt_rejected() -> None:
+    rec = base_record()
+    rec["input"] = {}
+    ok, err = validate_record(rec, plugin, require_json=False)
+    assert not ok
+    assert "prompt" in (err or "")
+
+
+def test_missing_json_rejected_when_schema() -> None:
+    rec = base_record()
+    ok, err = validate_record(rec, plugin, require_json=True)
+    assert not ok
+    assert "target.json required" in (err or "")
+
+
+def test_invalid_json_schema_rejected() -> None:
+    rec = base_record()
+    rec["target"] = {"json": {"foo": "bar"}}
+    ok, err = validate_record(rec, plugin, require_json=True)
+    assert not ok
+    assert "target.json invalid" in (err or "")

--- a/symphonia/sdk/cli.py
+++ b/symphonia/sdk/cli.py
@@ -23,12 +23,14 @@ from ..runtime.errors import (
     RegistryError,
     ModelLoadError,
 )
+from symphonia.training.train import main as train_command
 
 app = typer.Typer()
 plan_app = typer.Typer()
 registry_app = typer.Typer()
 app.add_typer(plan_app, name="plan")
 app.add_typer(registry_app, name="registry")
+app.command("train")(train_command)
 
 
 class ExitCode(IntEnum):

--- a/symphonia/training/__init__.py
+++ b/symphonia/training/__init__.py
@@ -1,0 +1,10 @@
+"""Training and evaluation utilities for Micrographia."""
+
+__all__ = [
+    "load_teacher",
+    "load_student",
+    "distill_loss",
+    "evaluate",
+    "load_dataset",
+    "train",
+]

--- a/symphonia/training/datasets.py
+++ b/symphonia/training/datasets.py
@@ -1,0 +1,34 @@
+"""Dataset loading utilities.
+
+This module provides helpers for reading small JSONL datasets used by the
+tests.  It intentionally keeps the implementation minimal so that the unit
+tests run quickly without requiring external dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+
+def load_dataset(path: str | Path, splits: Iterable[str]) -> Dict[str, List[dict]]:
+    """Load a JSONL dataset and partition by split field.
+
+    Each line of the dataset must contain a JSON object with a ``split`` field
+    designating which split (e.g. ``train``, ``val`` or ``test``) the example
+    belongs to.  Only examples whose split is present in ``splits`` are returned.
+    """
+
+    path = Path(path)
+    result: Dict[str, List[dict]] = {s: [] for s in splits}
+    with path.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            sp = obj.get("split")
+            if sp in result:
+                result[sp].append(obj)
+    return result

--- a/symphonia/training/distill.py
+++ b/symphonia/training/distill.py
@@ -1,0 +1,65 @@
+"""Minimal teacher and student models used for testing.
+
+The real project will eventually replace these stubs with calls into Hugging
+Face or other model libraries.  For the purposes of unit tests we keep the
+behaviour deterministic and very lightweight.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Teacher:
+    """Very small stub teacher model.
+
+    The teacher simply returns the input in upper case.  This deterministic
+    behaviour makes it easy to write tests without involving heavy models.
+    """
+
+    name: str
+
+    def predict(self, text: str) -> str:
+        return text.upper()
+
+
+@dataclass
+class Student:
+    """Simple student model that memorises teacher outputs."""
+
+    base: str
+    adapter: str
+    knowledge: dict[str, str] = field(default_factory=dict)
+
+    def predict(self, text: str) -> str:
+        """Return the learned output or a lower-cased fallback."""
+
+        return self.knowledge.get(text, text.lower())
+
+    def learn(self, text: str, target: str) -> None:
+        """Memorise ``target`` for ``text``."""
+
+        self.knowledge[text] = target
+
+
+def load_teacher(name: str) -> Teacher:
+    """Instantiate a :class:`Teacher` by ``name``."""
+
+    return Teacher(name)
+
+
+def load_student(base: str, adapter: str) -> Student:
+    """Instantiate a :class:`Student` with ``base`` model and ``adapter``."""
+
+    return Student(base=base, adapter=adapter)
+
+
+def distill_loss(student_out: str, teacher_out: str) -> float:
+    """Compute a tiny distillation loss.
+
+    The loss is ``0`` if the student matches the teacher and ``1`` otherwise.
+    """
+
+    return 0.0 if student_out == teacher_out else 1.0

--- a/symphonia/training/eval.py
+++ b/symphonia/training/eval.py
@@ -1,0 +1,34 @@
+"""Evaluation utilities for student models.
+
+The functions here compare a distilled student model against its teacher on a
+dataset and compute a handful of simple metrics.  They are intentionally
+minimal to keep tests fast.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from symphonia.training.distill import Teacher, Student
+
+
+def evaluate(student: Student, teacher: Teacher, data: Iterable[dict]) -> dict:
+    """Evaluate ``student`` on ``data`` and compute simple metrics."""
+
+    total = 0
+    correct = 0
+    for item in data:
+        inp = item["input"]
+        expected = item.get("target") or teacher.predict(inp)
+        pred = student.predict(inp)
+        if pred == expected:
+            correct += 1
+        total += 1
+    accuracy = correct / total if total else 0.0
+    metrics = {
+        "accuracy": accuracy,
+        "f1": accuracy,  # in this tiny setting precision=recall=accuracy
+        "loss": 1.0 - accuracy,
+        "student_vs_teacher_agreement": accuracy,
+    }
+    return metrics

--- a/symphonia/training/train.py
+++ b/symphonia/training/train.py
@@ -1,0 +1,124 @@
+"""Training command and utilities for distilling tiny models.
+
+The implementation here intentionally avoids heavy dependencies so that the
+test suite runs quickly.  It demonstrates the orchestration flow for loading a
+configuration, performing a mock training loop, evaluating the result and
+storing artifacts.
+"""
+
+from __future__ import annotations
+
+import json
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+import typer
+import yaml
+
+from symphonia.training.datasets import load_dataset
+from symphonia.training.distill import distill_loss, load_student, load_teacher
+from symphonia.training.eval import evaluate
+
+
+@dataclass
+class Config:
+    """Strongly typed view of the training configuration."""
+
+    model: Dict[str, Any]
+    data: Dict[str, Any]
+    training: Dict[str, Any]
+    logging: Dict[str, Any]
+
+
+class ConfigError(Exception):
+    """Raised when a configuration file is invalid."""
+
+    pass
+
+
+def load_config(path: Path) -> Config:
+    """Parse a YAML configuration file into a :class:`Config` object."""
+
+    try:
+        data = yaml.safe_load(Path(path).read_text())
+    except Exception as exc:  # pragma: no cover - yaml library errors
+        raise ConfigError(str(exc)) from exc
+    required = ["model", "data", "training", "logging"]
+    for key in required:
+        if key not in data:
+            raise ConfigError(f"missing '{key}' section")
+    return Config(**{k: data[k] for k in required})
+
+
+def _save_artifacts(output_dir: Path, config: Config, metrics: dict) -> str:
+    """Persist model artifacts and update a tiny registry.
+
+    Returns the SHA256 hash of the saved adapter to emulate real model
+    registries.
+    """
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "adapter.bin").write_bytes(b"stub")
+    (output_dir / "config.json").write_text(json.dumps(config.__dict__, indent=2))
+    (output_dir / "eval.json").write_text(json.dumps(metrics, indent=2))
+    (output_dir / "card.md").write_text("Model card\n===========\n")
+    sha = hashlib.sha256((output_dir / "adapter.bin").read_bytes()).hexdigest()
+    registry_path = output_dir.parent / "models_registry.json"
+    registry: list = []
+    if registry_path.exists():
+        registry = json.loads(registry_path.read_text())
+    registry.append({"path": str(output_dir), "hash": sha})
+    registry_path.write_text(json.dumps(registry, indent=2))
+    return sha
+
+
+def train(config: Config) -> dict:
+    """Run a mock training and evaluation loop using ``config``."""
+
+    teacher = load_teacher(config.data["teacher_model"])
+    student = load_student(config.model["base"], config.model.get("adapter", "full_ft"))
+
+    splits = config.data.get("split", ["train", "val"])
+    data = load_dataset(config.data["dataset"], splits)
+    train_data = data.get("train", [])
+    val_data = data.get("val", [])
+
+    for _ in range(config.training.get("epochs", 1)):
+        for item in train_data:
+            inp = item["input"]
+            teacher_out = teacher.predict(inp)
+            student_out = student.predict(inp)
+            _ = distill_loss(student_out, teacher_out)
+            student.learn(inp, teacher_out)
+
+    metrics = evaluate(student, teacher, val_data)
+    _save_artifacts(Path(config.model["output_dir"]), config, metrics)
+    return metrics
+
+
+cli = typer.Typer()
+
+
+@cli.command()
+def main(
+    config: Path = typer.Option(..., "--config", "-c", help="Path to YAML config"),
+    emit_summary: bool = typer.Option(False, "--emit-summary", is_flag=True),
+) -> None:
+    """Entry point for ``micrographonia train``."""
+
+    try:
+        cfg = load_config(config)
+        metrics = train(cfg)
+    except ConfigError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(2)
+    if emit_summary:
+        typer.echo(json.dumps(metrics))
+    else:
+        typer.echo(json.dumps(metrics, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()

--- a/tests/training/test_config_loader.py
+++ b/tests/training/test_config_loader.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import pytest
+
+from symphonia.training.train import Config, load_config, ConfigError
+
+
+def test_config_loader_valid(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        """
+model:
+  base: base-model
+  adapter: lora
+  output_dir: out
+data:
+  teacher_model: dummy
+  dataset: data.jsonl
+  split: [train, val]
+training:
+  epochs: 1
+  batch_size: 2
+logging:
+  wandb_project: micrographonia
+  save_every: 10
+"""
+    )
+    c = load_config(cfg)
+    assert isinstance(c, Config)
+    assert c.model["base"] == "base-model"
+
+
+def test_config_loader_invalid(tmp_path: Path) -> None:
+    cfg = tmp_path / "bad.yaml"
+    cfg.write_text("model: []: bad")
+    with pytest.raises(ConfigError):
+        load_config(cfg)

--- a/tests/training/test_eval_metrics.py
+++ b/tests/training/test_eval_metrics.py
@@ -1,0 +1,39 @@
+import json
+import sys
+import subprocess
+from pathlib import Path
+
+from tests.training.test_training_loop import _write_dataset
+
+
+def test_eval_metrics(tmp_path: Path) -> None:
+    data_path = tmp_path / "data.jsonl"
+    _write_dataset(data_path)
+    out_dir = tmp_path / "run"
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        f"""
+model:
+  base: base-model
+  adapter: lora
+  output_dir: {out_dir}
+data:
+  teacher_model: dummy
+  dataset: {data_path}
+  split: [train, val]
+training:
+  epochs: 1
+  batch_size: 2
+logging:
+  wandb_project: micrographonia
+  save_every: 10
+"""
+    )
+    subprocess.run(
+        [sys.executable, "-m", "symphonia.sdk.cli", "train", "--config", str(cfg)],
+        check=True,
+    )
+    metrics = json.loads((out_dir / "eval.json").read_text())
+    for key in ["accuracy", "f1", "loss", "student_vs_teacher_agreement"]:
+        assert key in metrics
+        assert 0 <= metrics[key] <= 1

--- a/tests/training/test_lora_setup.py
+++ b/tests/training/test_lora_setup.py
@@ -1,0 +1,6 @@
+from symphonia.training.distill import load_student
+
+
+def test_lora_setup() -> None:
+    student = load_student("base", adapter="lora")
+    assert student.adapter == "lora"

--- a/tests/training/test_registry_update.py
+++ b/tests/training/test_registry_update.py
@@ -1,0 +1,39 @@
+import json
+import sys
+import subprocess
+from pathlib import Path
+
+from tests.training.test_training_loop import _write_dataset
+
+
+def test_registry_update(tmp_path: Path) -> None:
+    data_path = tmp_path / "data.jsonl"
+    _write_dataset(data_path)
+    out_dir = tmp_path / "run"
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        f"""
+model:
+  base: base-model
+  adapter: lora
+  output_dir: {out_dir}
+data:
+  teacher_model: dummy
+  dataset: {data_path}
+  split: [train, val]
+training:
+  epochs: 1
+  batch_size: 2
+logging:
+  wandb_project: micrographonia
+  save_every: 10
+"""
+    )
+    subprocess.run(
+        [sys.executable, "-m", "symphonia.sdk.cli", "train", "--config", str(cfg)],
+        check=True,
+    )
+    registry_path = out_dir.parent / "models_registry.json"
+    registry = json.loads(registry_path.read_text())
+    assert any(entry["path"] == str(out_dir) for entry in registry)
+    assert all("hash" in entry for entry in registry)

--- a/tests/training/test_teacher_stub.py
+++ b/tests/training/test_teacher_stub.py
@@ -1,0 +1,6 @@
+from symphonia.training.distill import load_teacher
+
+
+def test_teacher_stub() -> None:
+    teacher = load_teacher("dummy")
+    assert teacher.predict("hello") == "HELLO"

--- a/tests/training/test_training_loop.py
+++ b/tests/training/test_training_loop.py
@@ -1,0 +1,45 @@
+import json
+import sys
+import subprocess
+from pathlib import Path
+
+
+def _write_dataset(path: Path) -> None:
+    lines = []
+    for i in range(20):
+        split = "train" if i < 15 else "val"
+        inp = f"sample {i}"
+        target = inp.upper()
+        lines.append(json.dumps({"input": inp, "target": target, "split": split}))
+    path.write_text("\n".join(lines))
+
+
+def test_training_loop(tmp_path: Path) -> None:
+    data_path = tmp_path / "data.jsonl"
+    _write_dataset(data_path)
+    out_dir = tmp_path / "run"
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        f"""
+model:
+  base: base-model
+  adapter: lora
+  output_dir: {out_dir}
+data:
+  teacher_model: dummy
+  dataset: {data_path}
+  split: [train, val]
+training:
+  epochs: 1
+  batch_size: 2
+logging:
+  wandb_project: micrographonia
+  save_every: 10
+"""
+    )
+    subprocess.run(
+        [sys.executable, "-m", "symphonia.sdk.cli", "train", "--config", str(cfg)],
+        check=True,
+    )
+    assert (out_dir / "adapter.bin").exists()
+    assert (out_dir / "eval.json").exists()


### PR DESCRIPTION
## Summary
- add stub training and evaluation modules with dataset loader and distillation
- wire training into CLI and expose `micrographonia` console script
- register models with hash and persist run artifacts
- switch to absolute imports and document training utilities
- validate datagen records and assign stable IDs for deterministic splits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72c8570188326ba8ca9c57b9b12cb