### PR TITLE
Add training quickstart documentation and scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Optional API keys for teacher generation
+OPENAI_API_KEY=
+GOOGLE_API_KEY=
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04
+
+WORKDIR /workspace
+COPY . /workspace
+RUN pip install --no-cache-dir -e .
+
+CMD ["bash"]
+

--- a/docs/quickstart_first_model.md
+++ b/docs/quickstart_first_model.md
@@ -1,0 +1,63 @@
+# Quickstart: Train Your First Model
+
+This guide walks through the minimal end-to-end path for training a tiny specialist with Micrographia.
+It assumes access to a single GPU (e.g. 2080, A10, or T4) and optional teacher APIs (OpenAI or Gemini).
+
+## 1. Assemble deterministic splits
+```bash
+python -m micrographonia.finetune.cli datagen-assemble \
+  --in examples/finetune/notes_kg/seeds_small.jsonl \
+  --out runs/finetune/noteskg/seeds.split.parquet
+```
+
+## 2. (Optional) Expand with a teacher
+```bash
+python -m micrographonia.finetune.cli datagen-generate \
+  --task notes_kg \
+  --seeds runs/finetune/noteskg/seeds.split.parquet \
+  --out runs/finetune/noteskg/raw.jsonl \
+  --json-only --max-examples 2000 --qps 2 --budget-usd 2.50 --strict
+```
+
+## 3. Filter & assemble final parquet splits
+```bash
+python -m micrographonia.finetune.cli datagen-filter \
+  --raw runs/finetune/noteskg/raw.jsonl \
+  --outdir runs/finetune/noteskg \
+  --min-json-valid 0.95 --drop-near-duplicates
+```
+
+## 4. Train a QLoRA adapter
+```bash
+python -m micrographonia.finetune.cli train-sft \
+  --config micrographonia/finetune/train/configs/sft_gemma270m_lora.yaml \
+  --exp noteskg
+```
+
+## 5. Evaluate the adapter
+```bash
+python -m micrographonia.finetune.cli eval-run \
+  --exp noteskg --config micrographonia/finetune/evals/configs/eval_default.yaml
+```
+
+## 6. Package the adapter and manifest
+```bash
+python -m micrographonia.finetune.cli package-export \
+  --exp noteskg --dest runs/finetune/noteskg/package
+```
+
+## 7. Orchestrate it in a plan
+```bash
+cp runs/finetune/noteskg/package/manifest.json examples/registry/manifests/extractor_A.local.json
+
+python -m micrographonia.sdk.cli plan.check-models \
+  --plan examples/manual_plans/notes_inproc.yml \
+  --registry examples/registry/manifests
+
+python -m micrographonia.sdk.cli plan.run \
+  --plan examples/manual_plans/notes_inproc.yml \
+  --registry examples/registry/manifests --emit-summary
+```
+
+Running all steps will yield a working in-process tool backed by your freshly trained adapter.
+

--- a/examples/registry/manifests/extractor_A.local.json
+++ b/examples/registry/manifests/extractor_A.local.json
@@ -1,0 +1,14 @@
+{
+  "name": "extractor_A.local",
+  "version": "v1",
+  "kind": "inproc",
+  "entrypoint": "examples.tools.extractor.factory",
+  "model": {
+    "base_id": "google/gemma-3-270m",
+    "adapter_uri": "file://runs/finetune/noteskg/package",
+    "loader": "peft-lora",
+    "quant": "4bit",
+    "device_hint": "auto"
+  }
+}
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,19 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 
+[project.optional-dependencies]
+finetune = [
+    "transformers>=4.39,<5",
+    "trl>=0.8",
+    "peft>=0.10",
+    "accelerate>=0.28",
+    "datasets>=2.19",
+    "huggingface_hub>=0.23",
+    "orjson>=3.9",
+    "bitsandbytes>=0.43; platform_system != 'Windows'",
+    "s3fs>=2023.9",
+]
+
 [project.scripts]
 micrographonia = "symphonia.sdk.cli:app"
 


### PR DESCRIPTION
## Summary
- document an end-to-end finetune workflow
- add optional finetune dependencies and environment examples
- include Dockerfile and sample local manifest for exported adapters

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a92fd152f48326ac193a2fc4bd4b08