### PR TITLE
fix: resolve lint errors

### DIFF
--- a/micrographonia/__init__.py
+++ b/micrographonia/__init__.py
@@ -5,7 +5,7 @@ to work while the underlying package is still named ``symphonia``.
 """
 from symphonia import *  # noqa: F401,F403
 import sys as _sys
-import symphonia as _symphonia
+import symphonia as symphonia
 import symphonia.finetune as _finetune
 import symphonia.sdk as _sdk
 import symphonia.registry as _registry

--- a/symphonia/training/distill.py
+++ b/symphonia/training/distill.py
@@ -8,7 +8,6 @@ behaviour deterministic and very lightweight.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- re-export `symphonia` in compatibility wrapper
- drop unused `typing.Any` import

## Testing
- `ruff check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9d6c6a4c4832681a4f01cb46b14b3